### PR TITLE
[WIP] e2e example of PbTokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+.idea
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,18 @@ exclude = [
 ]
 
 [dependencies]
-clear_on_drop = "0.2.3"
-crypto-mac = "0.7"
-curve25519-dalek = { version = "2", default-features = false }
-digest = "0.8"
-hmac = "0.7"
-rand = { version = "0.7.0", default-features = false }
+clear_on_drop = "0.2"
+crypto-mac = "0.10"
+curve25519-dalek = { version = "3", default-features = false }
+digest = "0.9"
+hmac = "0.10"
+rand = { version = "0.7", default-features = false }
+rand_core = "0.5.1"
 rand_chacha = "0.2.2"
 
 [dependencies.base64]
 optional = true
-version = "0.9.3"
+version = "0.13"
 
 [dependencies.serde]
 optional = true
@@ -34,14 +35,14 @@ default-features = false
 
 [dependencies.merlin]
 optional = true
-version = "1"
+version = "2"
 
 [dev-dependencies]
 serde_json = "1.0"
 serde = { version = "^1.0.0", features = ["derive"] }
-sha2 = "0.8"
-base64 = "0.9.3"
-rand = { version = "0.7.0", default-features = true }
+sha2 = "0.9"
+base64 = "0.13"
+rand = { version = "0.7", default-features = true }
 
 [features]
 nightly = ["clear_on_drop/nightly", "curve25519-dalek/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ hmac = "0.10"
 rand = { version = "0.7", default-features = false }
 rand_core = "0.5.1"
 rand_chacha = "0.2.2"
+sha2 = "0.9"
+lazy_static = "1.4"
 
 [dependencies.base64]
 optional = true
@@ -40,7 +42,6 @@ version = "2"
 [dev-dependencies]
 serde_json = "1.0"
 serde = { version = "^1.0.0", features = ["derive"] }
-sha2 = "0.9"
 base64 = "0.13"
 rand = { version = "0.7", default-features = true }
 

--- a/src/dleq.rs
+++ b/src/dleq.rs
@@ -65,12 +65,12 @@ impl DLEQProof {
         let A = A.compress();
         let B = B.compress();
 
-        h.input(X.as_bytes());
-        h.input(Y.as_bytes());
-        h.input(P.as_bytes());
-        h.input(Q.as_bytes());
-        h.input(A.as_bytes());
-        h.input(B.as_bytes());
+        h.update(X.as_bytes());
+        h.update(Y.as_bytes());
+        h.update(P.as_bytes());
+        h.update(Q.as_bytes());
+        h.update(A.as_bytes());
+        h.update(B.as_bytes());
 
         let c = Scalar::from_hash(h);
 
@@ -130,12 +130,12 @@ impl DLEQProof {
 
         let mut h = D::default();
 
-        h.input(X.as_bytes());
-        h.input(Y.as_bytes());
-        h.input(P.as_bytes());
-        h.input(Q.as_bytes());
-        h.input(A.as_bytes());
-        h.input(B.as_bytes());
+        h.update(X.as_bytes());
+        h.update(Y.as_bytes());
+        h.update(P.as_bytes());
+        h.update(Q.as_bytes());
+        h.update(A.as_bytes());
+        h.update(B.as_bytes());
 
         let c = Scalar::from_hash(h);
 
@@ -235,15 +235,15 @@ impl BatchDLEQProof {
 
         let mut h = D::default();
 
-        h.input(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
-        h.input(public_key.0.as_bytes());
+        h.update(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
+        h.update(public_key.0.as_bytes());
 
         for (Pi, Qi) in blinded_tokens.iter().zip(signed_tokens.iter()) {
-            h.input(Pi.0.as_bytes());
-            h.input(Qi.0.as_bytes());
+            h.update(Pi.0.as_bytes());
+            h.update(Qi.0.as_bytes());
         }
 
-        let result = h.result();
+        let result = h.finalize();
 
         let mut seed: [u8; 32] = [0u8; 32];
         seed.copy_from_slice(&result[..32]);

--- a/src/dleqor.rs
+++ b/src/dleqor.rs
@@ -22,9 +22,6 @@ use crate::pbtokens::*;
 /// The length of a `DLEQProof`, in bytes.
 pub const DLEQOR_PROOF_LENGTH: usize = 192;
 
-// todo: handle this constant
-/// Second generator used in PbTokens protocol
-pub const H_GENERATOR: RistrettoPoint = constants::RISTRETTO_BASEPOINT_POINT;
 
 /// A `DLEQProof` is a proof of the equivalence of the discrete logarithm between two pairs of points.
 #[allow(non_snake_case)]
@@ -99,6 +96,7 @@ impl DLEQORProof {
         let commitment_secret = [Scalar::random(rng); 2];
         let simulated_secrets = [Scalar::random(rng); 3];
 
+        // todo: probably here
         let mut commitments = [constants::RISTRETTO_BASEPOINT_POINT; 2];
         let mut alt_commitments = [constants::RISTRETTO_BASEPOINT_POINT; 2];
 
@@ -177,7 +175,7 @@ impl DLEQORProof {
             pk_X1: &(k.public_key.pk_X1.decompress()
                 .ok_or(TokenError(InternalError::PointDecompressionError))?),
             G: &constants::RISTRETTO_BASEPOINT_POINT,
-            H: &H_GENERATOR,
+            H: &(*H_GENERATOR),
             T: &decompressed_T,
             S: &point_S,
             W: &decompressed_W,
@@ -441,15 +439,18 @@ impl BatchDLEQORProof {
             &signing_key.public_key,
         )?;
 
-        // todo: handle these decompressions correctly
         let prover_assignments = ProveAssignments{
             sk_x: &signing_key.sk_x[bit as usize],
             sk_y: &signing_key.sk_y[bit as usize],
             b: &(bit as usize),
-            pk_X0: &signing_key.public_key.pk_X0.decompress().unwrap(),
-            pk_X1: &signing_key.public_key.pk_X1.decompress().unwrap(),
+            pk_X0: &signing_key.public_key.pk_X0
+                .decompress()
+                .ok_or(TokenError(InternalError::PointDecompressionError))?,
+            pk_X1: &signing_key.public_key.pk_X1
+                .decompress()
+                .ok_or(TokenError(InternalError::PointDecompressionError))?,
             G: &constants::RISTRETTO_BASEPOINT_POINT,
-            H: &constants::RISTRETTO_BASEPOINT_POINT,
+            H: &(*H_GENERATOR),
             T: &T_bar,
             S: &S_bar,
             W: &W_bar,
@@ -480,7 +481,7 @@ impl BatchDLEQORProof {
             pk_X0: &public_key.pk_X0,
             pk_X1: &public_key.pk_X1,
             G: &constants::RISTRETTO_BASEPOINT_COMPRESSED,
-            H: &constants::RISTRETTO_BASEPOINT_COMPRESSED,
+            H: &(*H_GENERATOR).compress(),
             T: &T_bar.compress(),
             S: &S_bar.compress(),
             W: &W_bar.compress(),

--- a/src/dleqor.rs
+++ b/src/dleqor.rs
@@ -1,0 +1,633 @@
+//! Code for DLEQOR proof.
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::vec::Vec;
+
+#[cfg(all(feature = "std"))]
+use std::vec::Vec;
+
+use core::iter;
+
+use curve25519_dalek::constants;
+use curve25519_dalek::ristretto::{RistrettoPoint, CompressedRistretto};
+use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::{VartimeMultiscalarMul, MultiscalarMul};
+use digest::generic_array::typenum::U64;
+use digest::Digest;
+use rand::{CryptoRng, Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+use crate::errors::{InternalError, TokenError};
+use crate::pbtokens::*;
+
+/// The length of a `DLEQProof`, in bytes.
+pub const DLEQOR_PROOF_LENGTH: usize = 192;
+
+/// A `DLEQProof` is a proof of the equivalence of the discrete logarithm between two pairs of points.
+#[allow(non_snake_case)]
+pub struct DLEQORProof {
+    /// `challenges` are the challenge of the ZKP
+    pub(crate) challenges: Vec<Scalar>,
+    /// `responses` are the provers responses
+    pub(crate) responses: Vec<(Scalar, Scalar)>,
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(DLEQORProof);
+
+#[cfg(feature = "serde")]
+impl_serde!(DLEQORProof);
+
+// todo: probably we want to give details of the proof itself.
+/// Assignments used by the prover
+pub struct ProveAssignments<'a> {
+    /// x secret key used in the signature
+    pub sk_x: &'a Scalar,
+    /// y secret key used in the signature
+    pub sk_y: &'a Scalar,
+    /// Bit used to sign
+    pub b: &'a usize,
+    /// Public key 0
+    pub pk_X0: &'a RistrettoPoint,
+    /// Public key 1
+    pub pk_X1: &'a RistrettoPoint,
+    /// First generator
+    pub G: &'a RistrettoPoint,
+    /// Second generator
+    pub H: &'a RistrettoPoint,
+    /// Point `T`
+    pub T: &'a RistrettoPoint,
+    /// Point `S`
+    pub S: &'a RistrettoPoint,
+    /// Point `W`
+    pub W: &'a RistrettoPoint,
+}
+
+/// Assignments used by the verifier
+pub struct VerifyAssignments<'a> {
+    /// Public key 0
+    pub pk_X0: &'a CompressedRistretto,
+    /// Public key 1
+    pub pk_X1: &'a CompressedRistretto,
+    /// First generator
+    pub G: &'a CompressedRistretto,
+    /// Second generator
+    pub H: &'a CompressedRistretto,
+    /// Point `T`
+    pub T: &'a CompressedRistretto,
+    /// Point `S`
+    pub S: &'a CompressedRistretto,
+    /// Point `W`
+    pub W: &'a CompressedRistretto,
+}
+
+#[allow(non_snake_case)]
+impl DLEQORProof {
+    /// Construct a new `DLEQProof`
+    // fn _new<D, T>(
+    fn new_alone<D, T>(
+        rng: &mut T,
+        assignments: ProveAssignments,
+    ) -> Result<Self, TokenError>
+        where
+            D: Digest<OutputSize = U64> + Default,
+            T: Rng + CryptoRng,
+    {
+        let bit = *assignments.b;
+        let commitment_secret = [Scalar::random(rng); 2];
+        let simulated_secrets = [Scalar::random(rng); 3];
+
+        let mut commitments = [constants::RISTRETTO_BASEPOINT_POINT; 2];
+        let mut alt_commitments = [constants::RISTRETTO_BASEPOINT_POINT; 2];
+
+        let public_keys = [*assignments.pk_X0, *assignments.pk_X1];
+        let pk_generators = [*assignments.G, *assignments.H];
+        let signature_generators = [*assignments.T, *assignments.S];
+        let simulated_pk_generators = [public_keys[1-bit], *assignments.G, *assignments.H];
+        let simulated_signature_generators = [*assignments.W, *assignments.T, *assignments.S];
+
+        commitments[bit] = RistrettoPoint::multiscalar_mul(&commitment_secret, &pk_generators);
+        commitments[1-bit] = RistrettoPoint::multiscalar_mul(&simulated_secrets, &simulated_pk_generators);
+
+        alt_commitments[bit] = RistrettoPoint::multiscalar_mul(&commitment_secret, &signature_generators);
+        alt_commitments[1-bit] = RistrettoPoint::multiscalar_mul(&simulated_secrets, &simulated_signature_generators);
+
+        let h = D::default()
+            .chain(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes())
+            .chain(assignments.G.compress().as_bytes())
+            .chain(assignments.H.compress().as_bytes())
+            .chain(assignments.T.compress().as_bytes())
+            .chain(assignments.S.compress().as_bytes())
+            .chain(assignments.W.compress().as_bytes())
+            .chain(assignments.pk_X0.compress().as_bytes())
+            .chain(assignments.pk_X1.compress().as_bytes())
+            .chain(commitments[0].compress().as_bytes())
+            .chain(commitments[1].compress().as_bytes())
+            .chain(alt_commitments[0].compress().as_bytes())
+            .chain(alt_commitments[1].compress().as_bytes());
+
+
+        let real_challenge = Scalar::from_hash(h);
+
+        let mut challenges = vec![Scalar::zero(); 2];
+        challenges[1-bit] = simulated_secrets[0];
+        challenges[bit] = real_challenge - challenges[1-bit];
+
+        let mut responses = vec![(Scalar::zero(), Scalar::zero()); 2];
+        responses[1-bit] = (simulated_secrets[1], simulated_secrets[2]);
+        responses[bit] = (
+            commitment_secret[0] - challenges[bit] * assignments.sk_x,
+            commitment_secret[1] - challenges[bit] * assignments.sk_y,
+        );
+
+        Ok(DLEQORProof {
+            challenges,
+            responses,
+        })
+    }
+
+    // /// Construct a new `DLEQProof`
+    // pub fn new<D, T>(
+    //     rng: &mut T,
+    //     blinded_token: &BlindedToken,
+    //     signed_token: &SignedToken,
+    //     k: &SigningKey,
+    // ) -> Result<Self, TokenError>
+    //     where
+    //         D: Digest<OutputSize = U64> + Default,
+    //         T: Rng + CryptoRng,
+    // {
+    //     Self::_new::<D, T>(
+    //         rng,
+    //         blinded_token
+    //             .0
+    //             .decompress()
+    //             .ok_or(TokenError(InternalError::PointDecompressionError))?,
+    //         signed_token
+    //             .0
+    //             .decompress()
+    //             .ok_or(TokenError(InternalError::PointDecompressionError))?,
+    //         k,
+    //     )
+    // }
+
+    /// Verify the `DLEQProof`
+    // fn _verify<D>(
+    fn verify_alone<D>(
+        &self,
+        assignments: VerifyAssignments,
+    ) -> Result<(), TokenError>
+        where
+            D: Digest<OutputSize = U64> + Default,
+    {
+        let commitments: [RistrettoPoint; 2] = [
+            RistrettoPoint::multiscalar_mul(
+                &[
+                    self.challenges[0],
+                    self.responses[0].0,
+                    self.responses[0].1,
+                ],
+                &[assignments.pk_X0.decompress().unwrap(), assignments.G.decompress().unwrap(), assignments.H.decompress().unwrap()],
+            ),
+            RistrettoPoint::multiscalar_mul(
+                &[
+                    self.challenges[1],
+                    self.responses[1].0,
+                    self.responses[1].1,
+                ],
+                &[assignments.pk_X1.decompress().unwrap(), assignments.G.decompress().unwrap(), assignments.H.decompress().unwrap()],
+            ),
+        ];
+
+        let simulated_commitments: [RistrettoPoint; 2] = [
+            RistrettoPoint::multiscalar_mul(
+                &[
+                    self.challenges[0],
+                    self.responses[0].0,
+                    self.responses[0].1,
+                ],
+                &[assignments.W.decompress().unwrap(), assignments.T.decompress().unwrap(), assignments.S.decompress().unwrap()],
+            ),
+            RistrettoPoint::multiscalar_mul(
+                &[
+                    self.challenges[1],
+                    self.responses[1].0,
+                    self.responses[1].1,
+                ],
+                &[assignments.W.decompress().unwrap(), assignments.T.decompress().unwrap(), assignments.S.decompress().unwrap()],
+            ),
+        ];
+        let h = D::default()
+            .chain(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes())
+            .chain(assignments.G.as_bytes())
+            .chain(assignments.H.as_bytes())
+            .chain(assignments.T.as_bytes())
+            .chain(assignments.S.as_bytes())
+            .chain(assignments.W.as_bytes())
+            .chain(assignments.pk_X0.as_bytes())
+            .chain(assignments.pk_X1.as_bytes())
+            .chain(commitments[0].compress().as_bytes())
+            .chain(commitments[1].compress().as_bytes())
+            .chain(simulated_commitments[0].compress().as_bytes())
+            .chain(simulated_commitments[1].compress().as_bytes());
+
+        let real_challenge = Scalar::from_hash(h);
+
+        if real_challenge == self.challenges[0] + self.challenges[1] {
+            Ok(())
+        } else {
+            Err(TokenError(InternalError::VerifyError))
+        }
+    }
+
+    // /// Verify the `DLEQProof`
+    // pub fn verify<D>(
+    //     &self,
+    //     blinded_token: &BlindedToken,
+    //     signed_token: &SignedToken,
+    //     public_key: &PublicKey,
+    // ) -> Result<(), TokenError>
+    //     where
+    //         D: Digest<OutputSize = U64> + Default,
+    // {
+    //     self._verify::<D>(
+    //         blinded_token
+    //             .0
+    //             .decompress()
+    //             .ok_or(TokenError(InternalError::PointDecompressionError))?,
+    //         signed_token
+    //             .0
+    //             .decompress()
+    //             .ok_or(TokenError(InternalError::PointDecompressionError))?,
+    //         public_key,
+    //     )
+    // }
+}
+
+impl DLEQORProof {
+    /// Convert this `DLEQProof` to a byte array.
+    pub fn to_bytes(&self) -> [u8; DLEQOR_PROOF_LENGTH] {
+        let mut proof_bytes: [u8; DLEQOR_PROOF_LENGTH] = [0u8; DLEQOR_PROOF_LENGTH];
+
+        proof_bytes[..32].copy_from_slice(&self.challenges[0].to_bytes());
+        proof_bytes[32..64].copy_from_slice(&self.challenges[1].to_bytes());
+        proof_bytes[64..96].copy_from_slice(&self.responses[0].0.to_bytes());
+        proof_bytes[96..128].copy_from_slice(&self.responses[0].1.to_bytes());
+        proof_bytes[128..160].copy_from_slice(&self.responses[1].0.to_bytes());
+        proof_bytes[160..].copy_from_slice(&self.responses[1].1.to_bytes());
+
+        proof_bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "DLEQProof",
+            length: DLEQOR_PROOF_LENGTH,
+        })
+    }
+
+    /// Construct a `DLEQProof` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<DLEQORProof, TokenError> {
+        if bytes.len() != DLEQOR_PROOF_LENGTH {
+            return Err(DLEQORProof::bytes_length_error());
+        }
+
+        let mut c_bits: [[u8; 32]; 2] = [[0u8; 32]; 2];
+        let mut s_bits: [([u8; 32], [u8; 32]); 2] = [([0u8; 32], [0u8; 32]); 2];
+
+        c_bits[0].copy_from_slice(&bytes[..32]);
+        c_bits[1].copy_from_slice(&bytes[32..64]);
+        s_bits[0].0.copy_from_slice(&bytes[64..96]);
+        s_bits[0].1.copy_from_slice(&bytes[96..128]);
+        s_bits[1].0.copy_from_slice(&bytes[128..160]);
+        s_bits[1].1.copy_from_slice(&bytes[160..192]);
+
+        let c = vec![
+            Scalar::from_canonical_bytes(c_bits[0])
+            .ok_or(TokenError(InternalError::ScalarFormatError))?,
+            Scalar::from_canonical_bytes(c_bits[1])
+                .ok_or(TokenError(InternalError::ScalarFormatError))?
+            ];
+        let s = vec![
+            (
+                Scalar::from_canonical_bytes(s_bits[0].0)
+            .ok_or(TokenError(InternalError::ScalarFormatError))?,
+                Scalar::from_canonical_bytes(s_bits[0].1)
+                    .ok_or(TokenError(InternalError::ScalarFormatError))?
+            ),
+            (
+                Scalar::from_canonical_bytes(s_bits[1].0)
+                    .ok_or(TokenError(InternalError::ScalarFormatError))?,
+                Scalar::from_canonical_bytes(s_bits[1].1)
+                    .ok_or(TokenError(InternalError::ScalarFormatError))?
+            )
+            ];
+
+        Ok(DLEQORProof { challenges: c, responses: s })
+    }
+}
+
+/// A `BatchDLEQProof` is a proof of the equivalence of the discrete logarithm between a common
+/// pair of points and one or more other pairs of points.
+#[allow(non_snake_case)]
+pub struct BatchDLEQORProof(DLEQORProof);
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(BatchDLEQORProof);
+
+#[cfg(feature = "serde")]
+impl_serde!(BatchDLEQORProof);
+
+#[allow(non_snake_case)]
+impl BatchDLEQORProof {
+    fn calculate_composites<D>(
+        blinded_tokens: &[BlindedPbToken],
+        signed_tokens: &[SignedPbToken],
+        S_vector: &[RistrettoPoint],
+        public_key: &PbPublicKey,
+    ) -> Result<(RistrettoPoint, RistrettoPoint, RistrettoPoint), TokenError>
+        where
+            D: Digest<OutputSize = U64> + Default,
+    {
+        if blinded_tokens.len() != signed_tokens.len() {
+            return Err(TokenError(InternalError::LengthMismatchError));
+        }
+
+        let mut h = D::default();
+
+        // todo: ensure that we are including tau correctly
+        h.input(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
+        h.input(public_key.pk_X0.as_bytes());
+        h.input(public_key.pk_X1.as_bytes());
+
+        for (Pi, Qi) in blinded_tokens.iter().zip(signed_tokens.iter()) {
+            h.input(Pi.0.as_bytes());
+            h.input(Qi.seed);
+            h.input(Qi.point.as_bytes());
+        }
+
+        for point in S_vector {
+            h.input(point.compress().as_bytes());
+        }
+
+        let result = h.result();
+
+        let mut seed: [u8; 32] = [0u8; 32];
+        seed.copy_from_slice(&result[..32]);
+
+        let mut prng: ChaChaRng = SeedableRng::from_seed(seed);
+        let c_m: Vec<Scalar> = iter::repeat_with(|| Scalar::random(&mut prng))
+            .take(blinded_tokens.len())
+            .collect();
+
+        let T_bar = RistrettoPoint::optional_multiscalar_mul(
+            &c_m,
+            blinded_tokens.iter().map(|Pi| Pi.0.decompress()),
+        )
+            .ok_or(TokenError(InternalError::PointDecompressionError))?;
+
+        let S_bar = RistrettoPoint::multiscalar_mul(
+            &c_m,
+            S_vector,
+        );
+
+        let W_bar = RistrettoPoint::optional_multiscalar_mul(
+            &c_m,
+            signed_tokens.iter().map(|Qi| Qi.point.decompress())
+        )
+            .ok_or(TokenError(InternalError::PointDecompressionError))?;
+
+        Ok((T_bar, S_bar, W_bar))
+    }
+
+    /// Construct a new `BatchDLEQProof`
+    pub fn new<D, T>(
+        rng: &mut T,
+        blinded_tokens: &[BlindedPbToken],
+        signed_tokens: &[SignedPbToken],
+        signing_key: &PbSigningKey,
+        bit: bool,
+    ) -> Result<Self, TokenError>
+        where
+            D: Digest<OutputSize = U64> + Default,
+            T: Rng + CryptoRng,
+    {
+        let mut S_vector = Vec::new();
+        for (bt, st) in blinded_tokens.iter().zip(signed_tokens.iter()) {
+            let mut hash = D::default();
+            hash.input(b"hash_derive_signing_point");
+            hash.input(st.seed);
+            hash.input(bt.0.as_bytes());
+
+            S_vector.push(RistrettoPoint::from_hash(hash));
+        }
+
+        let (T_bar, S_bar, W_bar) = BatchDLEQORProof::calculate_composites::<D>(
+            blinded_tokens,
+            signed_tokens,
+            &S_vector,
+            &signing_key.public_key,
+        )?;
+
+        // todo: handle these decompressions correctly
+        let prover_assignments = ProveAssignments{
+            sk_x: &signing_key.sk_x[bit as usize],
+            sk_y: &signing_key.sk_y[bit as usize],
+            b: &(bit as usize),
+            pk_X0: &signing_key.public_key.pk_X0.decompress().unwrap(),
+            pk_X1: &signing_key.public_key.pk_X1.decompress().unwrap(),
+            G: &constants::RISTRETTO_BASEPOINT_POINT,
+            H: &constants::RISTRETTO_BASEPOINT_POINT,
+            T: &T_bar,
+            S: &S_bar,
+            W: &W_bar,
+        };
+
+        Ok(BatchDLEQORProof(DLEQORProof::new_alone::<D, T>(
+            rng,
+            prover_assignments
+        )?))
+    }
+
+    /// Verify a `BatchDLEQProof`
+    pub fn verify<D>(
+        &self,
+        blinded_tokens: &[BlindedPbToken],
+        signed_tokens: &[SignedPbToken],
+        public_key: &PbPublicKey,
+    ) -> Result<(), TokenError>
+        where
+            D: Digest<OutputSize = U64> + Default,
+    {
+        let mut S_vector = Vec::new();
+        for (bt, st) in blinded_tokens.iter().zip(signed_tokens.iter()) {
+            let mut hash = D::default();
+            hash.input(b"hash_derive_signing_point");
+            hash.input(st.seed);
+            hash.input(bt.0.as_bytes());
+
+            S_vector.push(RistrettoPoint::from_hash(hash));
+        }
+
+        let (T_bar, S_bar, W_bar) =
+            BatchDLEQORProof::calculate_composites::<D>(blinded_tokens, signed_tokens, &S_vector, public_key)?;
+
+        let verify_assignments = VerifyAssignments{
+            pk_X0: &public_key.pk_X0,
+            pk_X1: &public_key.pk_X1,
+            G: &constants::RISTRETTO_BASEPOINT_COMPRESSED,
+            H: &constants::RISTRETTO_BASEPOINT_COMPRESSED,
+            T: &T_bar.compress(),
+            S: &S_bar.compress(),
+            W: &W_bar.compress(),
+        };
+
+        self.0.verify_alone::<D>(verify_assignments)
+    }
+
+    /// Verify the `BatchDLEQProof` then unblind the `SignedToken`s using each corresponding `Token`
+    pub fn verify_and_unblind<'a, D, I>(
+        &self,
+        tokens: I,
+        blinded_tokens: &[BlindedPbToken],
+        signed_tokens: &[SignedPbToken],
+        public_key: &PbPublicKey,
+    ) -> Result<Vec<UnblindedPbToken>, TokenError>
+        where
+            D: Digest<OutputSize = U64> + Default,
+            I: IntoIterator<Item = &'a PbToken>,
+    {
+        self.verify::<D>(blinded_tokens, signed_tokens, public_key)?;
+
+        let unblinded_tokens: Result<Vec<UnblindedPbToken>, TokenError> = tokens
+            .into_iter()
+            .zip(signed_tokens.iter())
+            .map(|(token, signed_token)| token.unblind::<D>(signed_token))
+            .collect();
+        unblinded_tokens.and_then(|unblinded_tokens| {
+            if unblinded_tokens.len() != signed_tokens.len() {
+                return Err(TokenError(InternalError::LengthMismatchError));
+            }
+            Ok(unblinded_tokens)
+        })
+    }
+}
+
+impl BatchDLEQORProof {
+    /// Convert this `BatchDLEQProof` to a byte array.
+    pub fn to_bytes(&self) -> [u8; DLEQOR_PROOF_LENGTH] {
+        self.0.to_bytes()
+    }
+
+    #[cfg(feature = "serde")]
+    fn bytes_length_error() -> TokenError {
+        DLEQORProof::bytes_length_error()
+    }
+
+    /// Construct a `BatchDLEQProof` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<BatchDLEQORProof, TokenError> {
+        DLEQORProof::from_bytes(bytes).map(BatchDLEQORProof)
+    }
+}
+
+// todo: we definitely want more tests here
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::Sha512;
+
+    #[test]
+    fn it_works_dleqor() {
+        let mut csrng = rand::rngs::OsRng;
+
+        let x = Scalar::random(&mut csrng);
+        let y = Scalar::random(&mut csrng);
+        let G = RistrettoPoint::random(&mut csrng);
+        let H = RistrettoPoint::random(&mut csrng);
+        let S = RistrettoPoint::random(&mut csrng);
+        let T = RistrettoPoint::random(&mut csrng);
+        let W = RistrettoPoint::multiscalar_mul(&[x, y], &[T, S]);
+        let X1 = RistrettoPoint::multiscalar_mul(&[x, y], &[G, H]);
+        let X0 = RistrettoPoint::random(&mut csrng);
+        let b = 1usize;
+
+        let proof = self::DLEQORProof::new_alone::<Sha512, rand::rngs::OsRng>(
+            &mut csrng,
+            ProveAssignments {
+                sk_x: &x,
+                sk_y: &y,
+                b: &b,
+                pk_X0: &X0,
+                pk_X1: &X1,
+                G: &G,
+                H: &H,
+                T: &T,
+                S: &S,
+                W: &W,
+            },
+        ).unwrap();
+
+        let verification = proof.verify_alone::<Sha512>(
+            VerifyAssignments {
+                pk_X0: &X0.compress(),
+                pk_X1: &X1.compress(),
+                G: &G.compress(),
+                H: &H.compress(),
+                T: &T.compress(),
+                S: &S.compress(),
+                W: &W.compress(),
+            },
+        );
+        assert!(verification.is_ok());
+    }
+
+    #[test]
+    fn to_bytes_works() {
+        let mut csrng = rand::rngs::OsRng;
+
+        let x = Scalar::random(&mut csrng);
+        let y = Scalar::random(&mut csrng);
+        let G = RistrettoPoint::random(&mut csrng);
+        let H = RistrettoPoint::random(&mut csrng);
+        let S = RistrettoPoint::random(&mut csrng);
+        let T = RistrettoPoint::random(&mut csrng);
+        let W = RistrettoPoint::multiscalar_mul(&[x, y], &[T, S]);
+        let X1 = RistrettoPoint::multiscalar_mul(&[x, y], &[G, H]);
+        let X0 = RistrettoPoint::random(&mut csrng);
+        let b = 1usize;
+
+        let proof = self::DLEQORProof::new_alone::<Sha512, rand::rngs::OsRng>(
+            &mut csrng,
+            ProveAssignments {
+                sk_x: &x,
+                sk_y: &y,
+                b: &b,
+                pk_X0: &X0,
+                pk_X1: &X1,
+                G: &G,
+                H: &H,
+                T: &T,
+                S: &S,
+                W: &W,
+            },
+        ).unwrap();
+
+        let proof_bytes = proof.to_bytes();
+
+        let reconverted_proof = self::DLEQORProof::from_bytes(&proof_bytes).unwrap();
+
+        let verification = reconverted_proof.verify_alone::<Sha512>(
+            VerifyAssignments {
+                pk_X0: &X0.compress(),
+                pk_X1: &X1.compress(),
+                G: &G.compress(),
+                H: &H.compress(),
+                T: &T.compress(),
+                S: &S.compress(),
+                W: &W.compress(),
+            },
+        );
+        assert!(verification.is_ok());
+    }
+
+}

--- a/src/dleqor.rs
+++ b/src/dleqor.rs
@@ -377,21 +377,21 @@ impl BatchDLEQORProof {
         let mut h = D::default();
 
         // todo: ensure that we are including tau correctly
-        h.input(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
-        h.input(public_key.pk_X0.as_bytes());
-        h.input(public_key.pk_X1.as_bytes());
+        h.update(constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
+        h.update(public_key.pk_X0.as_bytes());
+        h.update(public_key.pk_X1.as_bytes());
 
         for (Pi, Qi) in blinded_tokens.iter().zip(signed_tokens.iter()) {
-            h.input(Pi.0.as_bytes());
-            h.input(Qi.seed);
-            h.input(Qi.point.as_bytes());
+            h.update(Pi.0.as_bytes());
+            h.update(Qi.seed);
+            h.update(Qi.point.as_bytes());
         }
 
         for point in point_S_array {
-            h.input(point.compress().as_bytes());
+            h.update(point.compress().as_bytes());
         }
 
-        let result = h.result();
+        let result = h.finalize();
 
         let mut seed: [u8; 32] = [0u8; 32];
         seed.copy_from_slice(&result[..32]);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,6 +63,6 @@ impl Display for TokenError {
 #[cfg(feature = "std")]
 impl Error for TokenError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        return Some(&self.0);
+        Some(&self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,7 @@
 //! [`BatchDLEQProof`]: voprf/struct.BatchDLEQProof.html
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(feature = "nightly", doc(include = "../docs/PROTOCOL.md"))]
-//todo: remove this
-#![allow(dead_code)]
 #![allow(non_snake_case)]
-#![allow(unused_imports)]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
@@ -32,6 +29,9 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 #[macro_use]
 extern crate std;
+
+#[macro_use]
+extern crate lazy_static;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@
 //! [`BatchDLEQProof`]: voprf/struct.BatchDLEQProof.html
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(feature = "nightly", doc(include = "../docs/PROTOCOL.md"))]
+//todo: remove this
+#![allow(dead_code)]
+#![allow(non_snake_case)]
+#![allow(unused_imports)]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
@@ -34,10 +38,13 @@ mod macros;
 
 mod oprf;
 
+pub mod pbtokens;
 #[cfg(not(feature = "merlin"))]
 mod dleq;
 #[cfg(feature = "merlin")]
 mod dleq_merlin;
+
+pub mod dleqor;
 
 pub mod errors;
 pub mod voprf;

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -1,17 +1,14 @@
 use core::fmt::Debug;
 
 use clear_on_drop::clear::Clear;
-use crypto_mac::MacResult;
 use curve25519_dalek::constants;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use digest::generic_array::typenum::U64;
-use digest::Digest;
-use hmac::Mac;
+use digest::{Digest};
+use hmac::{Mac, NewMac};
 use rand::{CryptoRng, Rng};
-
-#[cfg(any(test, feature = "base64", feature = "serde"))]
-use hmac::digest::generic_array::GenericArray;
+use std::convert::TryInto;
 
 use crate::errors::{InternalError, TokenError};
 
@@ -42,7 +39,7 @@ pub struct TokenPreimage([u8; TOKEN_PREIMAGE_LENGTH]);
 
 impl PartialEq for TokenPreimage {
     fn eq(&self, other: &TokenPreimage) -> bool {
-        &self.0[..] == &other.0[..]
+        self.0[..] == other.0[..]
     }
 }
 
@@ -135,8 +132,8 @@ impl Token {
     {
         let mut hash = D::default();
         let mut seed = [0u8; 64];
-        hash.input(bytes);
-        seed.copy_from_slice(&hash.result().as_slice());
+        hash.update(bytes);
+        seed.copy_from_slice(&hash.finalize().as_slice());
 
         Token {
             t: TokenPreimage(seed),
@@ -450,12 +447,12 @@ impl UnblindedToken {
         D: Digest<OutputSize = U64> + Default,
     {
         let mut hash = D::default();
-        hash.input(b"hash_derive_key");
+        hash.update(b"hash_derive_key");
 
-        hash.input(self.t.0.as_ref());
-        hash.input(self.W.as_bytes());
+        hash.update(self.t.0.as_ref());
+        hash.update(self.W.as_bytes());
 
-        let output = hash.result();
+        let output = hash.finalize();
         let mut output_bytes = [0u8; 64];
         output_bytes.copy_from_slice(&output.as_slice());
 
@@ -511,19 +508,25 @@ impl VerificationKey {
     /// Use the `VerificationKey` to "sign" a message, producing a `VerificationSignature`
     pub fn sign<D>(&self, message: &[u8]) -> VerificationSignature
     where
-        D: Mac<OutputSize = U64>,
+        D: Mac<OutputSize = U64> + NewMac,
     {
         let mut mac = D::new_varkey(self.0.as_ref()).unwrap();
-        mac.input(message);
+        mac.update(message);
 
-        VerificationSignature(mac.result())
+        VerificationSignature(mac
+                .finalize()
+                .into_bytes()
+                .as_slice()
+                .try_into()
+            .expect("Output size is U64")
+        )
     }
 
     /// Use the `VerificationKey` to check that the signature of a message matches the
     /// provided `VerificationSignature`
     pub fn verify<D>(&self, sig: &VerificationSignature, message: &[u8]) -> bool
     where
-        D: Mac<OutputSize = U64>,
+        D: Mac<OutputSize = U64> + NewMac,
     {
         &self.sign::<D>(message) == sig
     }
@@ -531,7 +534,7 @@ impl VerificationKey {
 
 /// A `VerificationSignature` which can be verified given the `VerificationKey` and message
 #[cfg_attr(not(feature = "cbindgen"), repr(C))]
-pub struct VerificationSignature(MacResult<U64>);
+pub struct VerificationSignature([u8; VERIFICATION_SIGNATURE_LENGTH]);
 
 #[cfg(any(test, feature = "base64"))]
 impl_base64!(VerificationSignature);
@@ -541,18 +544,20 @@ impl_serde!(VerificationSignature);
 
 impl PartialEq for VerificationSignature {
     fn eq(&self, other: &VerificationSignature) -> bool {
-        self.0 == other.0
+        let mut comparison = false;
+        for i in 0..VERIFICATION_SIGNATURE_LENGTH {
+            comparison |= (self.0[i] == other.0[i]);
+        }
+        comparison
     }
 }
 
-#[cfg(any(test, feature = "base64", feature = "serde"))]
+#[cfg(any(test, feature = "serde", feature = "base64"))]
 impl VerificationSignature {
     /// Convert this `VerificationSignature` to a byte array.
     /// We intentionally keep this private to avoid accidental non constant time comparisons
     fn to_bytes(&self) -> [u8; VERIFICATION_SIGNATURE_LENGTH] {
-        let mut bytes: [u8; VERIFICATION_SIGNATURE_LENGTH] = [0u8; VERIFICATION_SIGNATURE_LENGTH];
-        bytes.copy_from_slice(self.0.clone().code().as_slice());
-        bytes
+        self.0.clone()
     }
 
     fn bytes_length_error() -> TokenError {
@@ -568,10 +573,13 @@ impl VerificationSignature {
             return Err(VerificationSignature::bytes_length_error());
         }
 
-        let arr: &GenericArray<u8, U64> = GenericArray::from_slice(bytes);
-        Ok(VerificationSignature(MacResult::new(*arr)))
+        let mut key: [u8; VERIFICATION_SIGNATURE_LENGTH] = [0u8; VERIFICATION_SIGNATURE_LENGTH];
+
+        key.copy_from_slice(&bytes[..]);
+        Ok(VerificationSignature(key))
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -582,7 +590,6 @@ mod tests {
     use base64;
 
     use super::*;
-
     type HmacSha512 = Hmac<Sha512>;
 
     #[allow(non_snake_case)]
@@ -590,16 +597,16 @@ mod tests {
     fn vector_tests() {
         // Generated using tools/oprf-test-gen
         let vectors = [
-("SlPD+7xZlw7l+Fr4E4dd/8E6kEouU65+ZfoN6m5iyQE=", "nGajOcg0T5IvwyBstdroFKWUwBd90yNcJU2cQJpluAg=", "nwfnvlVROHqYupd8cy0IDcsPKaBI42VpEsZTPjLueu0ptyF2nOZOQ9VxM7B02DnVMe0fKFEK+0Ws4QofS3lNbw==", "rBKvQjzCywrH+WAHjvVpB4P59cy1A0CCcYjeUioWdA0=", "iKt8hXS7Zyqy5/xbbknh/CuCmQM+Cti6uOibdKZBlEM=", "OFccZ1mrx9SSrRSoj95nEVmkbMAdggfpj6haKO0BrQQ=", "JFJyI4tUdjjtud9a4qZalp5i9QY4I0x/VhChVu4P714="),
-("7oD3U1ZwWQN/2eZhiXfHtnwmhR+yl3P7Gta+T123awI=", "vtiIh6vgqE9kaR/gvfo9rxps1pehPweuB1iJEM45ySc=", "5aaIdCtHxa37WdTfdv0dseUe4Dscqfgqyhc+24tyk0dOvpgPkE0QyRZEK0eDoOmEhgy2yVeznDjtj1HP+qaKTQ==", "yhpWSFSxFQRlZH9QtcmCrL1p27dYMEKs+sub7hfVbA8=", "qDUfb1GhqEsJg2MEo0jI5fUDsKitwSSkV6kaF3wWHBU=", "goTV+GGlPyIodeEfRu62nWVJFpj3lXMjZY6w4ABaolc=", "sgJfuuExkd+VoIXOr9gv+M7VlRnjnUtveVzWcOY6YzM="),
-("tviSLm/W8oFds67y9lMs990fjh08hQNV17/4V2bmOQY=", "5ufRlCvVKvXp1yuxxS7Jvw9LSwQUl6Q/MlT6HY2l1Hc=", "7aq3TaFBD8BV6gaMmekmCsvjN89dPgDlsyMP/tsLmQeH0McOC/5BmOpnWN1aYftf7C35gfMb7+FT+B0XFheE2w==", "Ge3prZ2jJSoh1A3ZvrSfaSA1kDziGW2I+Gmh6jniaAs=", "pOTANELrS8oor67hIYyCvrbmlMrn6Fr+04nBmFgrvxU=", "JjbfZ+UifRtHLdxcvVdI6C2SXYls9aWS0UyS6vyfCAY=", "Ki8Vb+Fm7qqeeL63/Oco95UaMOO62bRGq2fMTz5xPU8="),
-("2srhyAUoqF+s2y+NfSXluDXVxC7JBgiD2ttOSXBYPww=", "HhdUX1s812RxwznoreV7i/BHvj2Xy9tJo24GxNDmtF8=", "bQqtuvgVfQYqyyQYwXakdVEbNcP2IYpWaOpbxvVLh4L4s0DwCsG+ul5izWMqfOeAnHJWCKyl7798QfI3ZD8GwA==", "gfes2hjQSpt6QOBJnz4t/N/utBkdDS+W4GRQIYjb/wQ=", "ZnaqI3kpS5nh9B3jw6uOeUld//Q2+olaAlimWRFvcDE=", "0pISjRRLsiYWLzqiukHe1xkIEuDmibUcg9m/5zcPwSo=", "2lSAwKDv4mdzZuMSEEngBXSQBJRJoprzqKMtX9Bi/zs="),
-("pfwD6XL8PnQfJPuzg/LKKVf3QRLc4ZclvC+6GBBETgo=", "Vv9rfOewgYx7jHMyfAZfBFEBt5IuwIKwz2NbDpra+UM=", "FtP6gVFikwP+l0FWLtBl2068AFDvVYNkroESSij1wBMTIy+8SW39iiVoZXtobXIUOCoaAJAwF92paYeEQrpa/w==", "xrF8ZzEtEsGbRfJGjULVkNisgpaAO69AHZKYhyQmng4=", "rHUztBaoMDDVwOTnOxFQgEOEeG6lKBL7Tb+fluztCxo=", "dhQv3WoCFW+EcV1dpCARarugjhU/enn0UlamXDPoFxc=", "GgWeq8r+ZRsPJa50bP7y3kVAq7yBSSN8eM0oOn/U2CM="),
-("xNWxYjBW6Sty2Yy33S38IPkX6v4zAwK10Ge/WPxVVwU=", "GrqZp9KBIAi1mExq2VUhG8lIuNO/J9Ap4xATdJ5TfmM=", "xP/wuGwC7WYtLSUiZHofCaey+e6lbn4gsfBszdnOw347LSCBLfNpl4Y2wiZGYDZ1gEEEdF0pl+KN9dgkKq0ZyA==", "RclUsYJkWG7Uw0tM/rn+nyvDey/Ibwl7WkmmvkIPWwc=", "fiD5jlU2Bhu+chVrhWKvZTaVJnbmBTpDcfEAH9Kcjg4=", "mCFMTFdnxZ/gvTnVNGMmZkXWqlnnZH3JnwDKhTBT3x0=", "krmSP8LTAA0O35g7uk+o7MMYTl2qACiWu+CDZXtQJSo="),
-("lE2Tu2LzhNgU77KnsEFbqVYOc5wsbMYYzBQOcpi32Ag=", "EuJk2I4y6ZrbIn04deR+lzJS1xrBIpN+RthbPknv+gA=", "DPw4xN363pkKIT0gj794mDNPTe7X5YMP0mZ1ExVDWuGbuU9NPckmUvJD3R+W81latHPSNW2PqPbWTMT2SxLKmQ==", "Dbpt5WypybRRaQiInYndWLf/O2ewT3IEYOOdxKywNg8=", "QJH62wtVRKX0Eq1GTWVyAVuML0mpEl18VvxFn3TvTDI=", "TMRELsL1kWbyRNLQhWuIyU2j7M2FJk0trp+uR1w4hHw=", "nDiCPlbQ6HfR3MX9jRqY3id4DWo3GaZ1FvUfkmAjWyg="),
-("Tmfvkm6Kvi/BWAvqNsGsdQzJTI9tkGa4Sr0dNPTMCwc=", "iPXJcLCmT9SYYVYVfNx6br3VG1rHHF2hIrD2cVx8YGE=", "BdOrSDfezktj/f1d0HordqjIJWbfGiFn2uXhJbaqDna52ZyoRmT1Du6lTkSfDlhwORN/V1Q9iSBUgxQckzFmtg==", "0web3hpMwnqhIhu9mjAKNLfmFdJUfY3pu4clcs0G8AQ=", "Qll/1fI1hlcc3Dm6xtfo3LlJwu6fgoffCZ3VzzQvCAs=", "KNbnK4jL8SThHByYWWrzdpZHxvrTVid7aBYHnZD2BW0=", "Lti4tRDBQzwNIiTbGpPVVViHMvCEfC7ov2Ne3LrQdRg="),
-("N8oRiMuSrYdp9TMKp++AP8ridXqdX6BoPOucx2eRCQE=", "mnikks9ySHzZGMgoPZ0SRA8/JJkMh5aA+m3eqeMfqTE=", "9sNH3G618rH0vy3TKBMNRQDKOb66LUKBo9jOtMsezeN4sgAp+2pMVDMS5BATkVxXAW5dpoGUTMJ3+cfnX0plSg==", "f44zH9r/YnCyaHZnKtEc/68diotEo1GjQ5MWepNEXAk=", "EEH0FTbmxN5XoXnAHmIH0y4VjcixJ5U9T8WqXgP2IAg=", "Km0KASMeIqj0s5vswz+WEYptTx2Y0fOb9cVjb+UKexw=", "lNDdKND+R/JmDrM08Q7w7ePoXT7/hgzGU6xVBU5RFig="),
-("Nye8fMOQJv1HjCY6qxG0Br661wjd8OwNI1O0ZbkmGAc=", "5szoRS3/9jdVTmhswiS9yyaLeC2I0CfBAUzfe0zGjz8=", "OkOqxU+boJmNIhmzusoRGUDVJLfPlGd9bFV3UPpNueEHfu21um4zwQSuJUQ8hr8VgzU63fb93Rmk/0kRiOPUhw==", "ZBztTnJvQKmPkxfgzGzufhRa6o4oUPublpOIhODHKA4=", "lD1eLLmRw7ebLOd51OQSps51cZGTIg2DM+GL38bQQww=", "qA27hu9S60UX0jfnWJQgUBllQvfOPu+jQVkphi6Sv24=", "HhPZFQiNAYzG+niNmUiWut2g/YMhox86h1XyZypQfVk="),
+            ("SlPD+7xZlw7l+Fr4E4dd/8E6kEouU65+ZfoN6m5iyQE=", "nGajOcg0T5IvwyBstdroFKWUwBd90yNcJU2cQJpluAg=", "nwfnvlVROHqYupd8cy0IDcsPKaBI42VpEsZTPjLueu0ptyF2nOZOQ9VxM7B02DnVMe0fKFEK+0Ws4QofS3lNbw==", "rBKvQjzCywrH+WAHjvVpB4P59cy1A0CCcYjeUioWdA0=", "iKt8hXS7Zyqy5/xbbknh/CuCmQM+Cti6uOibdKZBlEM=", "OFccZ1mrx9SSrRSoj95nEVmkbMAdggfpj6haKO0BrQQ=", "JFJyI4tUdjjtud9a4qZalp5i9QY4I0x/VhChVu4P714="),
+            ("7oD3U1ZwWQN/2eZhiXfHtnwmhR+yl3P7Gta+T123awI=", "vtiIh6vgqE9kaR/gvfo9rxps1pehPweuB1iJEM45ySc=", "5aaIdCtHxa37WdTfdv0dseUe4Dscqfgqyhc+24tyk0dOvpgPkE0QyRZEK0eDoOmEhgy2yVeznDjtj1HP+qaKTQ==", "yhpWSFSxFQRlZH9QtcmCrL1p27dYMEKs+sub7hfVbA8=", "qDUfb1GhqEsJg2MEo0jI5fUDsKitwSSkV6kaF3wWHBU=", "goTV+GGlPyIodeEfRu62nWVJFpj3lXMjZY6w4ABaolc=", "sgJfuuExkd+VoIXOr9gv+M7VlRnjnUtveVzWcOY6YzM="),
+            ("tviSLm/W8oFds67y9lMs990fjh08hQNV17/4V2bmOQY=", "5ufRlCvVKvXp1yuxxS7Jvw9LSwQUl6Q/MlT6HY2l1Hc=", "7aq3TaFBD8BV6gaMmekmCsvjN89dPgDlsyMP/tsLmQeH0McOC/5BmOpnWN1aYftf7C35gfMb7+FT+B0XFheE2w==", "Ge3prZ2jJSoh1A3ZvrSfaSA1kDziGW2I+Gmh6jniaAs=", "pOTANELrS8oor67hIYyCvrbmlMrn6Fr+04nBmFgrvxU=", "JjbfZ+UifRtHLdxcvVdI6C2SXYls9aWS0UyS6vyfCAY=", "Ki8Vb+Fm7qqeeL63/Oco95UaMOO62bRGq2fMTz5xPU8="),
+            ("2srhyAUoqF+s2y+NfSXluDXVxC7JBgiD2ttOSXBYPww=", "HhdUX1s812RxwznoreV7i/BHvj2Xy9tJo24GxNDmtF8=", "bQqtuvgVfQYqyyQYwXakdVEbNcP2IYpWaOpbxvVLh4L4s0DwCsG+ul5izWMqfOeAnHJWCKyl7798QfI3ZD8GwA==", "gfes2hjQSpt6QOBJnz4t/N/utBkdDS+W4GRQIYjb/wQ=", "ZnaqI3kpS5nh9B3jw6uOeUld//Q2+olaAlimWRFvcDE=", "0pISjRRLsiYWLzqiukHe1xkIEuDmibUcg9m/5zcPwSo=", "2lSAwKDv4mdzZuMSEEngBXSQBJRJoprzqKMtX9Bi/zs="),
+            ("pfwD6XL8PnQfJPuzg/LKKVf3QRLc4ZclvC+6GBBETgo=", "Vv9rfOewgYx7jHMyfAZfBFEBt5IuwIKwz2NbDpra+UM=", "FtP6gVFikwP+l0FWLtBl2068AFDvVYNkroESSij1wBMTIy+8SW39iiVoZXtobXIUOCoaAJAwF92paYeEQrpa/w==", "xrF8ZzEtEsGbRfJGjULVkNisgpaAO69AHZKYhyQmng4=", "rHUztBaoMDDVwOTnOxFQgEOEeG6lKBL7Tb+fluztCxo=", "dhQv3WoCFW+EcV1dpCARarugjhU/enn0UlamXDPoFxc=", "GgWeq8r+ZRsPJa50bP7y3kVAq7yBSSN8eM0oOn/U2CM="),
+            ("xNWxYjBW6Sty2Yy33S38IPkX6v4zAwK10Ge/WPxVVwU=", "GrqZp9KBIAi1mExq2VUhG8lIuNO/J9Ap4xATdJ5TfmM=", "xP/wuGwC7WYtLSUiZHofCaey+e6lbn4gsfBszdnOw347LSCBLfNpl4Y2wiZGYDZ1gEEEdF0pl+KN9dgkKq0ZyA==", "RclUsYJkWG7Uw0tM/rn+nyvDey/Ibwl7WkmmvkIPWwc=", "fiD5jlU2Bhu+chVrhWKvZTaVJnbmBTpDcfEAH9Kcjg4=", "mCFMTFdnxZ/gvTnVNGMmZkXWqlnnZH3JnwDKhTBT3x0=", "krmSP8LTAA0O35g7uk+o7MMYTl2qACiWu+CDZXtQJSo="),
+            ("lE2Tu2LzhNgU77KnsEFbqVYOc5wsbMYYzBQOcpi32Ag=", "EuJk2I4y6ZrbIn04deR+lzJS1xrBIpN+RthbPknv+gA=", "DPw4xN363pkKIT0gj794mDNPTe7X5YMP0mZ1ExVDWuGbuU9NPckmUvJD3R+W81latHPSNW2PqPbWTMT2SxLKmQ==", "Dbpt5WypybRRaQiInYndWLf/O2ewT3IEYOOdxKywNg8=", "QJH62wtVRKX0Eq1GTWVyAVuML0mpEl18VvxFn3TvTDI=", "TMRELsL1kWbyRNLQhWuIyU2j7M2FJk0trp+uR1w4hHw=", "nDiCPlbQ6HfR3MX9jRqY3id4DWo3GaZ1FvUfkmAjWyg="),
+            ("Tmfvkm6Kvi/BWAvqNsGsdQzJTI9tkGa4Sr0dNPTMCwc=", "iPXJcLCmT9SYYVYVfNx6br3VG1rHHF2hIrD2cVx8YGE=", "BdOrSDfezktj/f1d0HordqjIJWbfGiFn2uXhJbaqDna52ZyoRmT1Du6lTkSfDlhwORN/V1Q9iSBUgxQckzFmtg==", "0web3hpMwnqhIhu9mjAKNLfmFdJUfY3pu4clcs0G8AQ=", "Qll/1fI1hlcc3Dm6xtfo3LlJwu6fgoffCZ3VzzQvCAs=", "KNbnK4jL8SThHByYWWrzdpZHxvrTVid7aBYHnZD2BW0=", "Lti4tRDBQzwNIiTbGpPVVViHMvCEfC7ov2Ne3LrQdRg="),
+            ("N8oRiMuSrYdp9TMKp++AP8ridXqdX6BoPOucx2eRCQE=", "mnikks9ySHzZGMgoPZ0SRA8/JJkMh5aA+m3eqeMfqTE=", "9sNH3G618rH0vy3TKBMNRQDKOb66LUKBo9jOtMsezeN4sgAp+2pMVDMS5BATkVxXAW5dpoGUTMJ3+cfnX0plSg==", "f44zH9r/YnCyaHZnKtEc/68diotEo1GjQ5MWepNEXAk=", "EEH0FTbmxN5XoXnAHmIH0y4VjcixJ5U9T8WqXgP2IAg=", "Km0KASMeIqj0s5vswz+WEYptTx2Y0fOb9cVjb+UKexw=", "lNDdKND+R/JmDrM08Q7w7ePoXT7/hgzGU6xVBU5RFig="),
+            ("Nye8fMOQJv1HjCY6qxG0Br661wjd8OwNI1O0ZbkmGAc=", "5szoRS3/9jdVTmhswiS9yyaLeC2I0CfBAUzfe0zGjz8=", "OkOqxU+boJmNIhmzusoRGUDVJLfPlGd9bFV3UPpNueEHfu21um4zwQSuJUQ8hr8VgzU63fb93Rmk/0kRiOPUhw==", "ZBztTnJvQKmPkxfgzGzufhRa6o4oUPublpOIhODHKA4=", "lD1eLLmRw7ebLOd51OQSps51cZGTIg2DM+GL38bQQww=", "qA27hu9S60UX0jfnWJQgUBllQvfOPu+jQVkphi6Sv24=", "HhPZFQiNAYzG+niNmUiWut2g/YMhox86h1XyZypQfVk="),
         ];
         for i in 0..vectors.len() {
             let (k, Y, seed, r, P, Q, W) = vectors[i];
@@ -675,5 +682,9 @@ mod tests {
 
         // The server compares the client signature to it's own
         assert!(client_sig == server_sig);
+
+        // and a failing equality
+        let server_sig_fail = server_verification_key.sign::<HmacSha512>(b"failing test message");
+        assert!(!(client_sig == server_sig_fail));
     }
 }

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -544,11 +544,17 @@ impl_serde!(VerificationSignature);
 
 impl PartialEq for VerificationSignature {
     fn eq(&self, other: &VerificationSignature) -> bool {
-        let mut comparison = false;
+        // These useless slices make the optimizer elide the bounds checks.
+        // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
+        // Reproducing constant time implementation of crate `constant_time_eq`,
+        // to avoid another dependency.
+        let a = &self.0[..VERIFICATION_SIGNATURE_LENGTH];
+        let b = &other.0[..VERIFICATION_SIGNATURE_LENGTH];
+        let mut comparison = 0;
         for i in 0..VERIFICATION_SIGNATURE_LENGTH {
-            comparison |= (self.0[i] == other.0[i]);
+            comparison |= a[i] ^ b[i];
         }
-        comparison
+        comparison == 0
     }
 }
 

--- a/src/pbtokens.rs
+++ b/src/pbtokens.rs
@@ -1,0 +1,783 @@
+//! Implementation of the private bit privacy pass tokens
+use core::fmt::Debug;
+
+use clear_on_drop::clear::Clear;
+use crypto_mac::MacResult;
+use curve25519_dalek::constants;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use curve25519_dalek::scalar::Scalar;
+use digest::generic_array::typenum::U64;
+use digest::Digest;
+use hmac::Mac;
+use rand::{CryptoRng, Rng};
+
+#[cfg(any(test, feature = "base64", feature = "serde"))]
+use hmac::digest::generic_array::GenericArray;
+
+use crate::errors::{InternalError, TokenError};
+
+/// The length of a `PbTokenPreimage`, in bytes.
+pub const PBTOKEN_PREIMAGE_LENGTH: usize = 64;
+/// The length of a `PbToken`, in bytes.
+pub const PBTOKEN_LENGTH: usize = PBTOKEN_PREIMAGE_LENGTH + 32;
+/// The length of a `BlindedPbToken`, in bytes.
+pub const BLINDED_PBTOKEN_LENGTH: usize = 32;
+/// The length of a `PbPublicKey`, in bytes.
+pub const PB_PUBLIC_KEY_LENGTH: usize = 64;
+/// The length of a `PbSigningKey`, in bytes.
+pub const PB_SIGNING_KEY_LENGTH: usize = 128;
+/// The length of a `SignedPbToken`, in bytes.
+pub const SIGNED_PBTOKEN_LENGTH: usize = 32 + PBTOKEN_PREIMAGE_LENGTH;
+/// The length of a `UnblindedPbToken`, in bytes.
+pub const UNBLINDED_PBTOKEN_LENGTH: usize = 64 + PBTOKEN_PREIMAGE_LENGTH;
+/// The length of a `PbVerificationSignature`, in bytes.
+pub const PB_VERIFICATION_SIGNATURE_LENGTH: usize = 64;
+
+/// A `PbTokenPreimage` is a slice of bytes which can be hashed to a `RistrettoPoint`.
+///
+/// The hash function must ensure the discrete log with respect to other points is unknown.
+/// In this construction `RistrettoPoint::from_uniform_bytes` is used as the hash function.
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[derive(Copy, Clone)]
+pub struct PbTokenPreimage([u8; PBTOKEN_PREIMAGE_LENGTH]);
+
+impl PartialEq for PbTokenPreimage {
+    fn eq(&self, other: &PbTokenPreimage) -> bool {
+        &self.0[..] == &other.0[..]
+    }
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(PbTokenPreimage);
+
+#[cfg(feature = "serde")]
+impl_serde!(PbTokenPreimage);
+
+impl Debug for PbTokenPreimage {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "PbTokenPreimage: {:?}", &self.0[..])
+    }
+}
+
+#[allow(non_snake_case)]
+impl PbTokenPreimage {
+    pub(crate) fn T(&self) -> RistrettoPoint {
+        RistrettoPoint::from_uniform_bytes(&self.0)
+    }
+
+    /// Convert this `PbTokenPreimage` to a byte array.
+    pub fn to_bytes(&self) -> [u8; PBTOKEN_PREIMAGE_LENGTH] {
+        self.0
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "PbTokenPreimage",
+            length: PBTOKEN_PREIMAGE_LENGTH,
+        })
+    }
+
+    /// Construct a `PbTokenPreimage` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<PbTokenPreimage, TokenError> {
+        if bytes.len() != PBTOKEN_PREIMAGE_LENGTH {
+            return Err(PbTokenPreimage::bytes_length_error());
+        }
+
+        let mut bits: [u8; PBTOKEN_PREIMAGE_LENGTH] = [0u8; PBTOKEN_PREIMAGE_LENGTH];
+        bits.copy_from_slice(&bytes);
+        Ok(PbTokenPreimage(bits))
+    }
+}
+
+/// A `PbToken` consists of a randomly chosen preimage and blinding factor.
+///
+/// Since a token includes the blinding factor it should be treated
+/// as a client secret and NEVER revealed to the server.
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[derive(Debug)]
+pub struct PbToken {
+    /// `t` is a `PbTokenPreimage`
+    pub(crate) t: PbTokenPreimage,
+    /// `r` is a `Scalar` which is the blinding factor
+    r: Scalar,
+}
+
+/// Overwrite the token blinding factor with null when it goes out of scope.
+impl Drop for PbToken {
+    fn drop(&mut self) {
+        self.r.clear();
+    }
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(PbToken);
+
+#[cfg(feature = "serde")]
+impl_serde!(PbToken);
+
+#[allow(non_snake_case)]
+impl PbToken {
+    /// Generates a new random `PbToken` using the provided random number generator.
+    pub fn random<D, T>(rng: &mut T) -> Self
+        where
+            D: Digest<OutputSize = U64> + Default,
+            T: Rng + CryptoRng,
+    {
+        let mut seed = [0u8; 64];
+        rng.fill(&mut seed);
+        let blinding_scalar = Scalar::random(rng);
+        Self::hash_from_bytes_with_blind::<D>(&seed, blinding_scalar)
+    }
+
+    /// Creates a new `PbToken`, using hashing to derive a `PbTokenPreimage` and the specified blind
+    pub(crate) fn hash_from_bytes_with_blind<D>(bytes: &[u8], blinding_scalar: Scalar) -> Self
+        where
+            D: Digest<OutputSize = U64> + Default,
+    {
+        let mut hash = D::default();
+        let mut seed = [0u8; 64];
+        hash.input(bytes);
+        seed.copy_from_slice(&hash.result().as_slice());
+
+        PbToken {
+            t: PbTokenPreimage(seed),
+            r: blinding_scalar,
+        }
+    }
+
+    /// Creates a new `PbToken`, using hashing to derive a `PbTokenPreimage` and a random blind
+    pub fn hash_from_bytes<D, T>(rng: &mut T, bytes: &[u8]) -> Self
+        where
+            D: Digest<OutputSize = U64> + Default,
+            T: Rng + CryptoRng,
+    {
+        let blinding_scalar = Scalar::random(rng);
+        Self::hash_from_bytes_with_blind::<D>(bytes, blinding_scalar)
+    }
+
+    /// Blinds the `PbToken`, returning a `BlindedPbToken` to be sent to the server.
+    pub fn blind(&self) -> BlindedPbToken {
+        BlindedPbToken((self.r * self.t.T()).compress())
+    }
+
+    /// Using the blinding factor of the original `PbToken`, unblind a `SignedPbToken`
+    /// returned from the server.
+    ///
+    /// Returns a `PbTokenError` if the `SignedPbToken` point is not valid.
+    pub (crate) fn unblind<D>(&self, Q: &SignedPbToken) -> Result<UnblindedPbToken, TokenError>
+    where
+        D: Digest<OutputSize = U64> + Default,
+    {
+        // todo: ensure these things coincide with the generation
+        let T = self.r * RistrettoPoint::from_uniform_bytes(&self.t.0);
+        let mut hash = D::default();
+        hash.input(b"hash_derive_signing_point");
+        hash.input(Q.seed);
+        hash.input(T.compress().as_bytes());
+
+        let S = RistrettoPoint::from_hash(hash);
+        let decompressed_Q = Q.point
+            .decompress()
+            .ok_or(TokenError(InternalError::PointDecompressionError))?;
+
+        let unblinded_S = self.r.invert() * S;
+        let unblinded_W = self.r.invert() * decompressed_Q;
+        Ok(UnblindedPbToken {
+            t: self.t,
+            sigma: [unblinded_S.compress(), unblinded_W.compress()]
+        })
+    }
+
+    /// Convert this `PbToken` to a byte array.
+    pub fn to_bytes(&self) -> [u8; PBTOKEN_LENGTH] {
+        let mut token_bytes: [u8; PBTOKEN_LENGTH] = [0u8; PBTOKEN_LENGTH];
+
+        token_bytes[..PBTOKEN_PREIMAGE_LENGTH].copy_from_slice(&self.t.to_bytes());
+        token_bytes[PBTOKEN_PREIMAGE_LENGTH..].copy_from_slice(&self.r.to_bytes());
+        token_bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "PbToken",
+            length: PBTOKEN_LENGTH,
+        })
+    }
+
+    /// Construct a `PbToken` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<PbToken, TokenError> {
+        if bytes.len() != PBTOKEN_LENGTH {
+            return Err(PbToken::bytes_length_error());
+        }
+
+        let preimage = PbTokenPreimage::from_bytes(&bytes[..PBTOKEN_PREIMAGE_LENGTH])?;
+
+        let mut blinding_factor_bits: [u8; 32] = [0u8; 32];
+        blinding_factor_bits.copy_from_slice(&bytes[PBTOKEN_PREIMAGE_LENGTH..]);
+        let blinding_factor = Scalar::from_canonical_bytes(blinding_factor_bits)
+            .ok_or(TokenError(InternalError::ScalarFormatError))?;
+
+        Ok(PbToken {
+            t: preimage,
+            r: blinding_factor,
+        })
+    }
+}
+
+/// A `BlindedPbToken` is sent to the server for signing.
+///
+/// It is the result of the scalar multiplication of the point derived from the token
+/// preimage with the blinding factor.
+///
+/// \\(P = T^r = H_1(t)^r\\)
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[derive(Copy, Clone, Debug)]
+pub struct BlindedPbToken(pub(crate) CompressedRistretto);
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(BlindedPbToken);
+
+#[cfg(feature = "serde")]
+impl_serde!(BlindedPbToken);
+
+impl BlindedPbToken {
+    /// Convert this `BlindedPbToken` to a byte array.
+    pub fn to_bytes(&self) -> [u8; BLINDED_PBTOKEN_LENGTH] {
+        self.0.to_bytes()
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "BlindedPbToken",
+            length: BLINDED_PBTOKEN_LENGTH,
+        })
+    }
+
+    /// Construct a `BlindedPbToken` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<BlindedPbToken, TokenError> {
+        if bytes.len() != BLINDED_PBTOKEN_LENGTH {
+            return Err(BlindedPbToken::bytes_length_error());
+        }
+
+        let mut bits: [u8; 32] = [0u8; 32];
+        bits.copy_from_slice(&bytes[..32]);
+        Ok(BlindedPbToken(CompressedRistretto(bits)))
+    }
+}
+
+/// A `PbPublicKey` is a committment by the server to a particular `PbSigningKey`.
+///
+/// \\(Y = X^k\\)
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[derive(Copy, Clone, Debug)]
+#[allow(non_snake_case)]
+pub struct PbPublicKey {
+    pub(crate) pk_X0: CompressedRistretto,
+    pub(crate) pk_X1: CompressedRistretto,
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(PbPublicKey);
+
+#[cfg(feature = "serde")]
+impl_serde!(PbPublicKey);
+
+impl PbPublicKey {
+    /// Convert this `PbPublicKey` to a byte array.
+    pub fn to_bytes(&self) -> [u8; PB_PUBLIC_KEY_LENGTH] {
+        let mut pk_bytes: [u8; PB_PUBLIC_KEY_LENGTH] = [0u8; PB_PUBLIC_KEY_LENGTH];
+
+        pk_bytes[..32].copy_from_slice(&self.pk_X0.to_bytes());
+        pk_bytes[32..].copy_from_slice(&self.pk_X1.to_bytes());
+        pk_bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "PbPublicKey",
+            length: PB_PUBLIC_KEY_LENGTH,
+        })
+    }
+
+    /// Construct a `PbPublicKey` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<PbPublicKey, TokenError> {
+        if bytes.len() != PB_PUBLIC_KEY_LENGTH {
+            return Err(PbPublicKey::bytes_length_error());
+        }
+
+        let mut bits_x0: [u8; 32] = [0u8; 32];
+        bits_x0.copy_from_slice(&bytes[..32]);
+        let mut bits_x1: [u8; 32] = [0u8; 32];
+        bits_x1.copy_from_slice(&bytes[32..]);
+
+        Ok(PbPublicKey {
+            pk_X0: CompressedRistretto(bits_x0),
+            pk_X1: CompressedRistretto(bits_x1),
+        })
+    }
+}
+
+/// A `PbSigningKey` is used to sign a `BlindedPbToken` and verify an `UnblindedPbToken`.
+///
+/// This is a server secret and should NEVER be revealed to the client.
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[derive(Debug)]
+pub struct PbSigningKey {
+    /// A `PbPublicKey` showing a committment to this particular key
+    pub public_key: PbPublicKey,
+    /// `k` is the actual key
+    pub(crate) sk_x: [Scalar; 2],
+    pub(crate) sk_y: [Scalar; 2],
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(PbSigningKey);
+
+#[cfg(feature = "serde")]
+impl_serde!(PbSigningKey);
+
+/// Overwrite signing key with null when it goes out of scope.
+impl Drop for PbSigningKey {
+    fn drop(&mut self) {
+        self.sk_x[0].clear();
+        self.sk_x[1].clear();
+        self.sk_y[0].clear();
+        self.sk_y[1].clear();
+    }
+}
+
+#[allow(non_snake_case)]
+impl PbSigningKey {
+    /// Generates a new random `PbSigningKey` using the provided random number generator.
+    pub fn random<T: Rng + CryptoRng>(rng: &mut T) -> Self {
+        let (mut pk_X0, mut pk_X1) = (constants::RISTRETTO_BASEPOINT_POINT, constants::RISTRETTO_BASEPOINT_POINT);
+        let (mut sk_x, mut sk_y) = ([Scalar::zero(); 2], [Scalar::zero(); 2]);
+        while pk_X0 == pk_X1 {
+            sk_x = [Scalar::random(rng), Scalar::random(rng)];
+            sk_y = [Scalar::random(rng), Scalar::random(rng)];
+
+            //todo: we need to agree on the second generator.
+            let H = constants::RISTRETTO_BASEPOINT_TABLE;
+            pk_X0 = &sk_x[0] * &constants::RISTRETTO_BASEPOINT_TABLE + &sk_y[0] * &H;
+            pk_X1 = &sk_x[1] * &constants::RISTRETTO_BASEPOINT_TABLE + &sk_y[1] * &H;
+        }
+        PbSigningKey {
+            sk_x,
+            sk_y,
+            public_key: PbPublicKey {pk_X0: pk_X0.compress(), pk_X1: pk_X1.compress()},
+        }
+    }
+
+    /// Signs the provided `BlindedPbToken`
+    ///
+    /// Returns None if the `BlindedPbToken` point is not valid.
+    pub fn sign<D, T>(&self, P: &BlindedPbToken, bit: bool, rng: &mut T) -> Result<SignedPbToken, TokenError>
+    where
+        D: Digest<OutputSize = U64> + Default,
+        T: Rng + CryptoRng,
+    {
+        let mut seed = [0u8; PBTOKEN_PREIMAGE_LENGTH];
+        rng.fill(&mut seed);
+
+        let mut hash = D::default();
+        hash.input(b"hash_derive_signing_point");
+        hash.input(seed);
+        hash.input(P.0.as_bytes());
+
+        let S = RistrettoPoint::from_hash(hash);
+        let decompressed_token = P.0
+            .decompress()
+            .ok_or(TokenError(InternalError::PointDecompressionError))?;
+        let W = self.sk_x[bit as usize] * decompressed_token  + self.sk_y[bit as usize] * S;
+
+        Ok(SignedPbToken {
+            point: W.compress(),
+            seed,
+        })
+    }
+
+    // todo: Give a more thorough description of the function
+    /// Check signature bit of received token. This checks the validity and the bit with
+    /// which it was signed.
+    pub fn check_signature_bit(&self, token: &UnblindedPbToken) -> Result<bool, TokenError>
+    {
+        let T = token.t.T();
+        let S = token.sigma[0]
+            .decompress()
+            .ok_or(TokenError(InternalError::PointDecompressionError))?;
+        let w_1 = &self.sk_x[0] * &T + &self.sk_y[0] * &S;
+        let w_2 = &self.sk_x[1] * &T + &self.sk_y[1] * &S;
+
+        if token.sigma[1] == w_1.compress() && token.sigma[1] != w_2.compress() {
+            Ok(false)
+        }
+        else if token.sigma[1] != w_1.compress() && token.sigma[1] == w_2.compress() {
+            Ok(true)
+        }
+        else {
+            Err(TokenError(InternalError::VerifyError))
+        }
+    }
+
+
+    /// Convert this `PbSigningKey` to a byte array.
+    pub fn to_bytes(&self) -> [u8; PB_SIGNING_KEY_LENGTH] {
+        let mut sk_bytes: [u8; PB_SIGNING_KEY_LENGTH] = [0u8; PB_SIGNING_KEY_LENGTH];
+
+        sk_bytes[..32].copy_from_slice(&self.sk_x[0].to_bytes());
+        sk_bytes[32..64].copy_from_slice(&self.sk_x[1].to_bytes());
+        sk_bytes[64..96].copy_from_slice(&self.sk_y[0].to_bytes());
+        sk_bytes[96..128].copy_from_slice(&self.sk_y[1].to_bytes());
+        sk_bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "PbSigningKey",
+            length: PB_SIGNING_KEY_LENGTH,
+        })
+    }
+
+    /// Construct a `PbSigningKey` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<PbSigningKey, TokenError> {
+        if bytes.len() != PB_SIGNING_KEY_LENGTH {
+            return Err(PbSigningKey::bytes_length_error());
+        }
+
+        let mut bits_x0: [u8; 32] = [0u8; 32];
+        let mut bits_x1: [u8; 32] = [0u8; 32];
+        let mut bits_y0: [u8; 32] = [0u8; 32];
+        let mut bits_y1: [u8; 32] = [0u8; 32];
+
+        bits_x0.copy_from_slice(&bytes[..32]);
+        bits_x1.copy_from_slice(&bytes[32..64]);
+        bits_y0.copy_from_slice(&bytes[64..96]);
+        bits_y1.copy_from_slice(&bytes[96..128]);
+
+        let x0 = Scalar::from_canonical_bytes(bits_x0)
+            .ok_or(TokenError(InternalError::ScalarFormatError))?;
+        let x1 = Scalar::from_canonical_bytes(bits_x1)
+            .ok_or(TokenError(InternalError::ScalarFormatError))?;
+        let y0 = Scalar::from_canonical_bytes(bits_y0)
+            .ok_or(TokenError(InternalError::ScalarFormatError))?;
+        let y1 = Scalar::from_canonical_bytes(bits_y1)
+            .ok_or(TokenError(InternalError::ScalarFormatError))?;
+
+        // todo: need to agree on second generator
+        let H = constants::RISTRETTO_BASEPOINT_TABLE;
+        let pk_X0 = &x0 * &constants::RISTRETTO_BASEPOINT_TABLE + &y0 * &H;
+        let pk_X1 = &x1 * &constants::RISTRETTO_BASEPOINT_TABLE + &y1 * &H;
+
+        Ok(PbSigningKey {
+            public_key: PbPublicKey {pk_X0: pk_X0.compress(), pk_X1: pk_X1.compress()},
+            sk_x: [x0, x1],
+            sk_y: [y0, y1],
+        })
+    }
+}
+
+/// A `SignedPbToken` is the result of signing a `BlindedPbToken`.
+///
+/// \\(Q = P^k = (T^r)^k\\)
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[derive(Copy, Clone, Debug)]
+pub struct SignedPbToken {
+    pub(crate) point: CompressedRistretto,
+    pub(crate) seed: [u8; PBTOKEN_PREIMAGE_LENGTH],
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(SignedPbToken);
+
+#[cfg(feature = "serde")]
+impl_serde!(SignedPbToken);
+
+impl SignedPbToken {
+    /// Convert this `SignedPbToken` to a byte array.
+    pub fn to_bytes(&self) -> [u8; SIGNED_PBTOKEN_LENGTH] {
+        let mut st_bytes: [u8; SIGNED_PBTOKEN_LENGTH] = [0u8; SIGNED_PBTOKEN_LENGTH];
+
+        st_bytes[..PBTOKEN_PREIMAGE_LENGTH].copy_from_slice(&self.seed);
+        st_bytes[PBTOKEN_PREIMAGE_LENGTH..].copy_from_slice(&self.point.to_bytes());
+        st_bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "SignedPbToken",
+            length: SIGNED_PBTOKEN_LENGTH,
+        })
+    }
+
+    /// Construct a `SignedPbToken` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<SignedPbToken, TokenError> {
+        if bytes.len() != SIGNED_PBTOKEN_LENGTH {
+            return Err(SignedPbToken::bytes_length_error());
+        }
+
+        let mut bits_seed: [u8; PBTOKEN_PREIMAGE_LENGTH] = [0u8; PBTOKEN_PREIMAGE_LENGTH];
+        let mut bits_point: [u8; 32] = [0u8; 32];
+        bits_seed.copy_from_slice(&bytes[..PBTOKEN_PREIMAGE_LENGTH]);
+        bits_point.copy_from_slice(&bytes[PBTOKEN_PREIMAGE_LENGTH..]);
+        Ok(
+            SignedPbToken {
+                point: CompressedRistretto(bits_point),
+                seed: bits_seed
+            }
+        )
+    }
+}
+
+/// An `UnblindedPbToken` is the result of unblinding a `SignedPbToken`.
+///
+/// While both the client and server both "know" this value,
+/// it should nevertheless not be sent between the two.
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+#[allow(non_snake_case)]
+#[derive(Clone, Copy, Debug)]
+pub struct UnblindedPbToken {
+    /// `t` is the `PbTokenPreimage`
+    pub t: PbTokenPreimage,
+    /// `sigma` is the unblinded values S and W
+    ///
+    /// \\(S = S'^{1/r}\\)
+    /// \\(W = W'^{1/r}\\)
+    sigma: [CompressedRistretto; 2],
+}
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(UnblindedPbToken);
+
+#[cfg(feature = "serde")]
+impl_serde!(UnblindedPbToken);
+
+impl UnblindedPbToken {
+    /// Derive the `PbVerificationKey` for this particular `UnblindedPbToken`
+    pub fn derive_verification_key<D>(&self) -> PbVerificationKey
+        where
+            D: Digest<OutputSize = U64> + Default,
+    {
+        let mut hash = D::default();
+        hash.input(b"hash_derive_key");
+
+        hash.input(self.t.0.as_ref());
+        hash.input(self.sigma[0].as_bytes());
+        hash.input(self.sigma[1].as_bytes());
+
+        let output = hash.result();
+        let mut output_bytes = [0u8; 64];
+        output_bytes.copy_from_slice(&output.as_slice());
+
+        PbVerificationKey(output_bytes)
+    }
+
+    /// Convert this `UnblindedPbToken` to a byte array.
+    pub fn to_bytes(&self) -> [u8; UNBLINDED_PBTOKEN_LENGTH] {
+        let mut unblinded_token_bytes: [u8; UNBLINDED_PBTOKEN_LENGTH] = [0u8; UNBLINDED_PBTOKEN_LENGTH];
+
+        unblinded_token_bytes[..32].copy_from_slice(&self.sigma[0].to_bytes());
+        unblinded_token_bytes[32..64].copy_from_slice(&self.sigma[1].to_bytes());
+        unblinded_token_bytes[64..].copy_from_slice(&self.t.to_bytes());
+        unblinded_token_bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "UnblindedPbToken",
+            length: UNBLINDED_PBTOKEN_LENGTH,
+        })
+    }
+
+    /// Construct a `UnblindedPbToken` from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<UnblindedPbToken, TokenError> {
+        if bytes.len() != UNBLINDED_PBTOKEN_LENGTH {
+            return Err(UnblindedPbToken::bytes_length_error());
+        }
+
+        let preimage = PbTokenPreimage::from_bytes(&bytes[64..])?;
+
+        let mut sigma_s_bits: [u8; 32] = [0u8; 32];
+        let mut sigma_w_bits: [u8; 32] = [0u8; 32];
+        sigma_s_bits.copy_from_slice(&bytes[..32]);
+        sigma_w_bits.copy_from_slice(&bytes[32..64]);
+        Ok(UnblindedPbToken {
+            t: preimage,
+            sigma: [CompressedRistretto(sigma_s_bits), CompressedRistretto(sigma_w_bits)],
+        })
+    }
+}
+
+/// The shared `PbVerificationKey` for proving / verifying the validity of an `UnblindedPbToken`.
+///
+/// \\(K = H_2(t, W)\\)
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+pub struct PbVerificationKey([u8; 64]);
+
+impl Debug for PbVerificationKey {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "VerificationKey: {:?}", &self.0[..])
+    }
+}
+
+impl PbVerificationKey {
+    /// Use the `PbVerificationKey` to "sign" a message, producing a `PbVerificationSignature`
+    pub fn sign<D>(&self, message: &[u8]) -> PbVerificationSignature
+        where
+            D: Mac<OutputSize = U64>,
+    {
+        let mut mac = D::new_varkey(self.0.as_ref()).unwrap();
+        mac.input(message);
+
+        PbVerificationSignature(mac.result())
+    }
+
+    /// Use the `PbVerificationKey` to check that the signature of a message matches the
+    /// provided `PbVerificationSignature`
+    pub fn verify<D>(&self, sig: &PbVerificationSignature, message: &[u8]) -> bool
+        where
+            D: Mac<OutputSize = U64>,
+    {
+        &self.sign::<D>(message) == sig
+    }
+}
+
+/// A `PbVerificationSignature` which can be verified given the `PbVerificationKey` and message
+#[cfg_attr(not(feature = "cbindgen"), repr(C))]
+pub struct PbVerificationSignature(MacResult<U64>);
+
+#[cfg(any(test, feature = "base64"))]
+impl_base64!(PbVerificationSignature);
+
+#[cfg(feature = "serde")]
+impl_serde!(PbVerificationSignature);
+
+impl PartialEq for PbVerificationSignature {
+    fn eq(&self, other: &PbVerificationSignature) -> bool {
+        self.0 == other.0
+    }
+}
+
+#[cfg(any(test, feature = "base64", feature = "serde"))]
+impl PbVerificationSignature {
+    /// Convert this `VerificationSignature` to a byte array.
+    /// We intentionally keep this private to avoid accidental non constant time comparisons
+    fn to_bytes(&self) -> [u8; PB_VERIFICATION_SIGNATURE_LENGTH] {
+        let mut bytes: [u8; PB_VERIFICATION_SIGNATURE_LENGTH] = [0u8; PB_VERIFICATION_SIGNATURE_LENGTH];
+        bytes.copy_from_slice(self.0.clone().code().as_slice());
+        bytes
+    }
+
+    fn bytes_length_error() -> TokenError {
+        TokenError(InternalError::BytesLengthError {
+            name: "VerificationSignature",
+            length: PB_VERIFICATION_SIGNATURE_LENGTH,
+        })
+    }
+
+    /// Construct a `VerificationSignature` from a slice of bytes.
+    fn from_bytes(bytes: &[u8]) -> Result<PbVerificationSignature, TokenError> {
+        if bytes.len() != PB_VERIFICATION_SIGNATURE_LENGTH {
+            return Err(PbVerificationSignature::bytes_length_error());
+        }
+
+        let arr: &GenericArray<u8, U64> = GenericArray::from_slice(bytes);
+        Ok(PbVerificationSignature(MacResult::new(*arr)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hmac::Hmac;
+    use rand::rngs::OsRng;
+    use sha2::Sha512;
+
+    use base64;
+
+    use super::*;
+
+    type HmacSha512 = Hmac<Sha512>;
+
+//     #[allow(non_snake_case)]
+//     #[test]
+//     fn vector_tests() {
+//         // Generated using tools/oprf-test-gen
+//         let vectors = [
+//             ("SlPD+7xZlw7l+Fr4E4dd/8E6kEouU65+ZfoN6m5iyQE=", "nGajOcg0T5IvwyBstdroFKWUwBd90yNcJU2cQJpluAg=", "nwfnvlVROHqYupd8cy0IDcsPKaBI42VpEsZTPjLueu0ptyF2nOZOQ9VxM7B02DnVMe0fKFEK+0Ws4QofS3lNbw==", "rBKvQjzCywrH+WAHjvVpB4P59cy1A0CCcYjeUioWdA0=", "iKt8hXS7Zyqy5/xbbknh/CuCmQM+Cti6uOibdKZBlEM=", "OFccZ1mrx9SSrRSoj95nEVmkbMAdggfpj6haKO0BrQQ=", "JFJyI4tUdjjtud9a4qZalp5i9QY4I0x/VhChVu4P714="),
+//             ("7oD3U1ZwWQN/2eZhiXfHtnwmhR+yl3P7Gta+T123awI=", "vtiIh6vgqE9kaR/gvfo9rxps1pehPweuB1iJEM45ySc=", "5aaIdCtHxa37WdTfdv0dseUe4Dscqfgqyhc+24tyk0dOvpgPkE0QyRZEK0eDoOmEhgy2yVeznDjtj1HP+qaKTQ==", "yhpWSFSxFQRlZH9QtcmCrL1p27dYMEKs+sub7hfVbA8=", "qDUfb1GhqEsJg2MEo0jI5fUDsKitwSSkV6kaF3wWHBU=", "goTV+GGlPyIodeEfRu62nWVJFpj3lXMjZY6w4ABaolc=", "sgJfuuExkd+VoIXOr9gv+M7VlRnjnUtveVzWcOY6YzM="),
+//             ("tviSLm/W8oFds67y9lMs990fjh08hQNV17/4V2bmOQY=", "5ufRlCvVKvXp1yuxxS7Jvw9LSwQUl6Q/MlT6HY2l1Hc=", "7aq3TaFBD8BV6gaMmekmCsvjN89dPgDlsyMP/tsLmQeH0McOC/5BmOpnWN1aYftf7C35gfMb7+FT+B0XFheE2w==", "Ge3prZ2jJSoh1A3ZvrSfaSA1kDziGW2I+Gmh6jniaAs=", "pOTANELrS8oor67hIYyCvrbmlMrn6Fr+04nBmFgrvxU=", "JjbfZ+UifRtHLdxcvVdI6C2SXYls9aWS0UyS6vyfCAY=", "Ki8Vb+Fm7qqeeL63/Oco95UaMOO62bRGq2fMTz5xPU8="),
+//             ("2srhyAUoqF+s2y+NfSXluDXVxC7JBgiD2ttOSXBYPww=", "HhdUX1s812RxwznoreV7i/BHvj2Xy9tJo24GxNDmtF8=", "bQqtuvgVfQYqyyQYwXakdVEbNcP2IYpWaOpbxvVLh4L4s0DwCsG+ul5izWMqfOeAnHJWCKyl7798QfI3ZD8GwA==", "gfes2hjQSpt6QOBJnz4t/N/utBkdDS+W4GRQIYjb/wQ=", "ZnaqI3kpS5nh9B3jw6uOeUld//Q2+olaAlimWRFvcDE=", "0pISjRRLsiYWLzqiukHe1xkIEuDmibUcg9m/5zcPwSo=", "2lSAwKDv4mdzZuMSEEngBXSQBJRJoprzqKMtX9Bi/zs="),
+//             ("pfwD6XL8PnQfJPuzg/LKKVf3QRLc4ZclvC+6GBBETgo=", "Vv9rfOewgYx7jHMyfAZfBFEBt5IuwIKwz2NbDpra+UM=", "FtP6gVFikwP+l0FWLtBl2068AFDvVYNkroESSij1wBMTIy+8SW39iiVoZXtobXIUOCoaAJAwF92paYeEQrpa/w==", "xrF8ZzEtEsGbRfJGjULVkNisgpaAO69AHZKYhyQmng4=", "rHUztBaoMDDVwOTnOxFQgEOEeG6lKBL7Tb+fluztCxo=", "dhQv3WoCFW+EcV1dpCARarugjhU/enn0UlamXDPoFxc=", "GgWeq8r+ZRsPJa50bP7y3kVAq7yBSSN8eM0oOn/U2CM="),
+//             ("xNWxYjBW6Sty2Yy33S38IPkX6v4zAwK10Ge/WPxVVwU=", "GrqZp9KBIAi1mExq2VUhG8lIuNO/J9Ap4xATdJ5TfmM=", "xP/wuGwC7WYtLSUiZHofCaey+e6lbn4gsfBszdnOw347LSCBLfNpl4Y2wiZGYDZ1gEEEdF0pl+KN9dgkKq0ZyA==", "RclUsYJkWG7Uw0tM/rn+nyvDey/Ibwl7WkmmvkIPWwc=", "fiD5jlU2Bhu+chVrhWKvZTaVJnbmBTpDcfEAH9Kcjg4=", "mCFMTFdnxZ/gvTnVNGMmZkXWqlnnZH3JnwDKhTBT3x0=", "krmSP8LTAA0O35g7uk+o7MMYTl2qACiWu+CDZXtQJSo="),
+//             ("lE2Tu2LzhNgU77KnsEFbqVYOc5wsbMYYzBQOcpi32Ag=", "EuJk2I4y6ZrbIn04deR+lzJS1xrBIpN+RthbPknv+gA=", "DPw4xN363pkKIT0gj794mDNPTe7X5YMP0mZ1ExVDWuGbuU9NPckmUvJD3R+W81latHPSNW2PqPbWTMT2SxLKmQ==", "Dbpt5WypybRRaQiInYndWLf/O2ewT3IEYOOdxKywNg8=", "QJH62wtVRKX0Eq1GTWVyAVuML0mpEl18VvxFn3TvTDI=", "TMRELsL1kWbyRNLQhWuIyU2j7M2FJk0trp+uR1w4hHw=", "nDiCPlbQ6HfR3MX9jRqY3id4DWo3GaZ1FvUfkmAjWyg="),
+//             ("Tmfvkm6Kvi/BWAvqNsGsdQzJTI9tkGa4Sr0dNPTMCwc=", "iPXJcLCmT9SYYVYVfNx6br3VG1rHHF2hIrD2cVx8YGE=", "BdOrSDfezktj/f1d0HordqjIJWbfGiFn2uXhJbaqDna52ZyoRmT1Du6lTkSfDlhwORN/V1Q9iSBUgxQckzFmtg==", "0web3hpMwnqhIhu9mjAKNLfmFdJUfY3pu4clcs0G8AQ=", "Qll/1fI1hlcc3Dm6xtfo3LlJwu6fgoffCZ3VzzQvCAs=", "KNbnK4jL8SThHByYWWrzdpZHxvrTVid7aBYHnZD2BW0=", "Lti4tRDBQzwNIiTbGpPVVViHMvCEfC7ov2Ne3LrQdRg="),
+//             ("N8oRiMuSrYdp9TMKp++AP8ridXqdX6BoPOucx2eRCQE=", "mnikks9ySHzZGMgoPZ0SRA8/JJkMh5aA+m3eqeMfqTE=", "9sNH3G618rH0vy3TKBMNRQDKOb66LUKBo9jOtMsezeN4sgAp+2pMVDMS5BATkVxXAW5dpoGUTMJ3+cfnX0plSg==", "f44zH9r/YnCyaHZnKtEc/68diotEo1GjQ5MWepNEXAk=", "EEH0FTbmxN5XoXnAHmIH0y4VjcixJ5U9T8WqXgP2IAg=", "Km0KASMeIqj0s5vswz+WEYptTx2Y0fOb9cVjb+UKexw=", "lNDdKND+R/JmDrM08Q7w7ePoXT7/hgzGU6xVBU5RFig="),
+//             ("Nye8fMOQJv1HjCY6qxG0Br661wjd8OwNI1O0ZbkmGAc=", "5szoRS3/9jdVTmhswiS9yyaLeC2I0CfBAUzfe0zGjz8=", "OkOqxU+boJmNIhmzusoRGUDVJLfPlGd9bFV3UPpNueEHfu21um4zwQSuJUQ8hr8VgzU63fb93Rmk/0kRiOPUhw==", "ZBztTnJvQKmPkxfgzGzufhRa6o4oUPublpOIhODHKA4=", "lD1eLLmRw7ebLOd51OQSps51cZGTIg2DM+GL38bQQww=", "qA27hu9S60UX0jfnWJQgUBllQvfOPu+jQVkphi6Sv24=", "HhPZFQiNAYzG+niNmUiWut2g/YMhox86h1XyZypQfVk="),
+//         ];
+//         for i in 0..vectors.len() {
+//             let (k, Y, seed, r, P, Q, W) = vectors[i];
+//
+//             let server_key = SigningKey::decode_base64(k).unwrap();
+//             let seed = base64::decode(seed).unwrap();
+//
+//             assert!(server_key.public_key.encode_base64() == Y);
+//
+//             let r_bytes = base64::decode(r).unwrap();
+//             let mut r_bits: [u8; 32] = [0u8; 32];
+//             r_bits.copy_from_slice(&r_bytes);
+//             let r = Scalar::from_canonical_bytes(r_bits).unwrap();
+//
+//             let token = Token::hash_from_bytes_with_blind::<Sha512>(&seed, r);
+//
+//             let blinded_token = token.blind();
+//
+//             assert!(blinded_token.encode_base64() == P);
+//
+//             let mut rng = OsRng;
+//             let signed_token = server_key.sign(&blinded_token, true, rng).unwrap();
+//
+//             assert!(signed_token.encode_base64() == Q);
+//
+//             let unblinded_token = token.unblind(&signed_token).unwrap();
+//
+//             let W_bytes = base64::decode(W).unwrap();
+//             let mut W_bits: [u8; 32] = [0u8; 32];
+//             W_bits.copy_from_slice(&W_bytes[..32]);
+//             let W = CompressedRistretto(W_bits);
+//
+//             let unblinded_token_expected = UnblindedToken { W: W, t: token.t };
+//             assert!(unblinded_token.encode_base64() == unblinded_token_expected.encode_base64());
+//         }
+//     }
+//
+    #[test]
+    fn works() {
+        let mut rng = OsRng;
+
+        // Server setup
+
+        let server_key = PbSigningKey::random(&mut rng);
+
+        // Signing
+
+        // client prepares a random token and blinding scalar
+        let token = PbToken::random::<Sha512, _>(&mut rng);
+        // client blinds the token and sends it to the server
+        let blinded_token = token.blind();
+
+        // server signs the blinded token and returns it to the client
+        let signed_token = server_key.sign::<Sha512, _>(&blinded_token, false, &mut rng).unwrap();
+
+        // client uses the blinding scalar to unblind the returned signed token
+        let unblinded_token = token.unblind::<Sha512>(&signed_token).unwrap();
+
+        // Redemption
+
+        // client sends the token preimage, signature and message to the server
+
+        // server checks the validity and the boolean of the client
+        let server_bit_verification = server_key.check_signature_bit(&unblinded_token).unwrap();
+
+        // The server uses the output bit for verification.
+        assert!(server_bit_verification == false);
+    }
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -41,6 +41,7 @@ struct Client {
     unblinded_tokens: Vec<UnblindedToken>,
 }
 
+#[cfg(not(feature = "merlin"))]
 impl Client {
     fn create_tokens(&mut self, n: u8) -> SigningRequest {
         let mut rng = OsRng;
@@ -105,6 +106,7 @@ struct Server {
     spent_tokens: Vec<TokenPreimage>,
 }
 
+#[cfg(not(feature = "merlin"))]
 impl Server {
     fn sign_tokens(&self, req: SigningRequest) -> SigningResponse {
         let mut rng = OsRng;
@@ -156,6 +158,7 @@ impl Server {
 }
 
 #[test]
+#[cfg(not(feature = "merlin"))]
 fn e2e_works() {
     let mut rng = OsRng;
     let signing_key = SigningKey::random(&mut rng);

--- a/tests/e2e_pbtokens.rs
+++ b/tests/e2e_pbtokens.rs
@@ -12,33 +12,34 @@ use sha2::Sha512;
 use serde::{Deserialize, Serialize};
 
 use challenge_bypass_ristretto::errors::*;
-use challenge_bypass_ristretto::voprf::*;
+use challenge_bypass_ristretto::pbtokens::*;
+use challenge_bypass_ristretto::dleqor::*;
 
 type HmacSha512 = Hmac<Sha512>;
 
 #[cfg_attr(feature = "serde_base64", derive(Serialize, Deserialize))]
 struct SigningRequest {
-    blinded_tokens: Vec<BlindedToken>,
+    blinded_tokens: Vec<BlindedPbToken>,
 }
 
 #[cfg_attr(feature = "serde_base64", derive(Serialize, Deserialize))]
 struct SigningResponse {
-    signed_tokens: Vec<SignedToken>,
-    public_key: PublicKey,
-    batch_proof: BatchDLEQProof,
+    signed_tokens: Vec<SignedPbToken>,
+    public_key: PbPublicKey,
+    batch_proof: BatchDLEQORProof,
 }
 
 #[cfg_attr(feature = "serde_base64", derive(Serialize, Deserialize))]
 struct RedeemRequest {
-    preimages: Vec<TokenPreimage>,
-    verification_signatures: Vec<VerificationSignature>,
+    unblinded_tokens: Vec<UnblindedPbToken>,
+    verification_signatures: Vec<PbVerificationSignature>,
     payload: Vec<u8>,
 }
 
 struct Client {
-    tokens: Vec<Token>,
-    blinded_tokens: Vec<BlindedToken>,
-    unblinded_tokens: Vec<UnblindedToken>,
+    tokens: Vec<PbToken>,
+    blinded_tokens: Vec<BlindedPbToken>,
+    unblinded_tokens: Vec<UnblindedPbToken>,
 }
 
 impl Client {
@@ -47,7 +48,7 @@ impl Client {
 
         for _i in 0..n {
             // client prepares a random token and blinding scalar
-            let token = Token::random::<Sha512, OsRng>(&mut rng);
+            let token = PbToken::random::<Sha512, OsRng>(&mut rng);
 
             // client blinds the token
             let blinded_token = token.blind();
@@ -64,6 +65,7 @@ impl Client {
     }
 
     fn store_signed_tokens(&mut self, resp: SigningResponse) -> Result<(), TokenError> {
+
         self.unblinded_tokens
             .append(&mut resp.batch_proof.verify_and_unblind::<Sha512, _>(
                 &self.tokens,
@@ -78,13 +80,9 @@ impl Client {
 
     fn redeem_tokens(&self) -> RedeemRequest {
         let payload = b"test message".to_vec();
-
-        let mut preimages: Vec<TokenPreimage> = vec![];
-        let mut verification_signatures: Vec<VerificationSignature> = vec![];
+        let mut verification_signatures = Vec::new();
 
         for unblinded_token in self.unblinded_tokens.iter() {
-            preimages.push(unblinded_token.t);
-
             // client derives the shared key from the unblinded token
             let verification_key = unblinded_token.derive_verification_key::<Sha512>();
 
@@ -93,7 +91,7 @@ impl Client {
         }
 
         RedeemRequest {
-            preimages,
+            unblinded_tokens: self.unblinded_tokens.clone(),
             verification_signatures,
             payload,
         }
@@ -101,8 +99,8 @@ impl Client {
 }
 
 struct Server {
-    signing_key: SigningKey,
-    spent_tokens: Vec<TokenPreimage>,
+    signing_key: PbSigningKey,
+    spent_tokens: Vec<PbTokenPreimage>,
 }
 
 impl Server {
@@ -111,19 +109,21 @@ impl Server {
 
         let public_key = self.signing_key.public_key;
 
-        let signed_tokens: Vec<SignedToken> = req
+        // todo: we probably want a fancier test for the bit marks
+        let signed_tokens: Vec<SignedPbToken> = req
             .blinded_tokens
             .iter()
-            .filter_map(|t| self.signing_key.sign(t).ok())
+            .filter_map(|t| self.signing_key.sign::<Sha512, _>(t, false, &mut rng).ok())
             .collect();
 
-        let batch_proof = BatchDLEQProof::new::<Sha512, OsRng>(
+        let batch_proof = BatchDLEQORProof::new::<Sha512, OsRng>(
             &mut rng,
             &req.blinded_tokens,
             &signed_tokens,
             &self.signing_key,
+            false
         )
-        .unwrap();
+            .unwrap();
 
         SigningResponse {
             signed_tokens,
@@ -133,12 +133,10 @@ impl Server {
     }
 
     fn redeem_tokens(&mut self, req: &RedeemRequest) {
-        for (preimage, client_sig) in req.preimages.iter().zip(req.verification_signatures.iter()) {
+        for (unblinded_token, client_sig) in req.unblinded_tokens.iter().zip(req.verification_signatures.iter()) {
+            let preimage = unblinded_token.t;
             // the server checks that the preimage has not previously been speant
-            assert!(!self.spent_tokens.contains(preimage));
-
-            // server derives the unblinded token using it's key and the clients token preimage
-            let unblinded_token = self.signing_key.rederive_unblinded_token(preimage);
+            assert!(!self.spent_tokens.contains(&preimage));
 
             // server derives the shared key from the unblinded token
             let verification_key = unblinded_token.derive_verification_key::<Sha512>();
@@ -149,16 +147,26 @@ impl Server {
             // the server compares the client signature to it's own
             assert!(*client_sig == sig);
 
+            // Now we check the correctness of the signature and its corresponding bit
+            let signature_bit = self.signing_key.check_signature_bit(unblinded_token);
+
+            // The server ensures the signature is valid
+            assert!(signature_bit.is_ok());
+
+            // The server applies logic depending on the bit
+            let result = if signature_bit.unwrap() {"reputable"} else {"non-reputable"};
+            println!("{}", result);
+
             // the server marks the token as spent
-            self.spent_tokens.push(*preimage);
+            self.spent_tokens.push(preimage);
         }
     }
 }
 
 #[test]
-fn e2e_works() {
+fn e2e_pbtokens_works() {
     let mut rng = OsRng;
-    let signing_key = SigningKey::random(&mut rng);
+    let signing_key = PbSigningKey::random(&mut rng);
 
     let mut client = Client {
         tokens: Vec::new(),
@@ -183,7 +191,7 @@ fn e2e_works() {
 #[test]
 fn e2e_serde_works() {
     let mut rng = OsRng;
-    let signing_key = SigningKey::random(&mut rng);
+    let signing_key = PbSigningKey::random(&mut rng);
 
     let mut client = Client {
         tokens: Vec::new(),


### PR DESCRIPTION
Extension of the challenge bypass crate to use Private Bit Tokens. 

Main changes in the API:
- Time of signature, the server needs to specify the label assigned to the user (which is a bool)
- Time of redemption, the verification function not only verifies the validity of the token, but also returns the bit assigned to that particular token

ToDos: 
- [x] abstract the caller of the zkp of the prover/verifier assignments. Use pks, blinded and signed tokens