### PR TITLE
Update to criterion 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "^1.0.0", features = ["derive"] }
 sha2 = "0.10"
 base64 = "0.13"
 rand = { version = "0.8", default-features = true }
-criterion = { version = "0.3.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
 default = ["std"]

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -31,7 +31,7 @@ pub fn e2e_server_benchmarks(c: &mut Criterion) {
 
     let signing_req = client.create_tokens(n_tokens);
 
-    c.bench_function("sing pre-tokens", |b| {
+    c.bench_function("sign pre-tokens", |b| {
         b.iter(|| {
             let _signing_resp = server.sign_tokens(signing_req.clone());
         });


### PR DESCRIPTION
- Use the latest release of the benchmarking framework
- Fix typo

The function `Client::store_signed_tokens` is never called in the e2e benchmark. Wasn't sure what to do with that.