### PR TITLE
Fix minor clippy warnings

### DIFF
--- a/src/dleq.rs
+++ b/src/dleq.rs
@@ -393,8 +393,7 @@ mod tests {
 ("tviSLm/W8oFds67y9lMs990fjh08hQNV17/4V2bmOQY=", "5ufRlCvVKvXp1yuxxS7Jvw9LSwQUl6Q/MlT6HY2l1Hc=", "zOVEbK4KQ1GBW97YUVNguoN+NntwtGi1t+EeioMusXY=", "lH2gNbwqSC1nYYxT3I7fNQagTsD4OvSbzwrSCpanQkQ=", "NJF9U3TWiCWMd6Qh/vA90F/2N6udsXbTvifNxf0rzgbhInoEvYDi5jZAZUQEi7x7mmP8iFq7+ukoOroy6/8jCw=="),
 ("Ge3prZ2jJSoh1A3ZvrSfaSA1kDziGW2I+Gmh6jniaAs=", "2nNCd5YN9H5EYlOL9/kmLYNBMkaLwnG3wjyd7jw2QAY=", "YHdAzlpSTAMy3mB+F4mPwlyVl+V9Yt4f3cDPNJpWdns=", "gEnqgXg3FDaCQFayTXrIfpbZ2n0P6FD/95LuMsdIfFk=", "Fj2/YunbQs5XxSyLxl/fC4dAfRlErGurTtHHSfGKyQTzrLZrO7VghmGFQaMAXZ+jg+6v99YL6FWj1Y/5WFt2Aw=="),
         ];
-        for i in 0..vectors.len() {
-            let (k, Y, P, Q_b64, dleq_b64) = vectors[i];
+        for (k, Y, P, Q_b64, dleq_b64) in vectors {
 
             let server_key = SigningKey::decode_base64(k).unwrap();
 
@@ -430,8 +429,7 @@ mod tests {
 ("siv+BM3AvP8Jv1aL4MFhMs9Xa6jxUNhFXpTWDfGrZQQ=", "XgFOlHEz5zm5dtx6ptYIXNg1NsJ/3vAq+cf/9eBkbxI=", "dsaMl4/9FcOFtaW3l65y1Z9ETJR36aTcXPMp+w4HGUY=,aH2q1HiReMA/Ney2NNZCgl+5GKK9xrxVwdC+THq9pFY=,uGRqS51VD7DuK0gSpMb3owRld57W6DqOyZpygXJVpmI=,Bvv+lqtCg39SD1H218rPZdQTmYPe2HD3QScntqw1oFA=,9IHWUyv/SCwZ4WKEGi58+bQ5nHsaDBXCku2vOzGvgUY=", "4lPV/OyNjVy4VTUvaROxCuq4ryfegkt7jt5IhrX9THo=,4EAmV5Mv3a/IQFsfVlaFxErNc96Ns980FT4yLlCdoxA=,bgGM37uBMLdRRAd1cu/4Iq+FzFwzRFLVhqp2uGFnPQc=,rCn4OuWnV5tTsgcPJAYRSqfONZf9k/92fwzWHtUxxh8=,lHCDzazDlU0w735u7OQmJM96WGeaNFILanawmC9EwFE=", "jotItTWLW/kpDeh8KJQtNqM7ON0YibEJ7R8VnMHP7Cs=", "Pu49xb3Ixn+Dfg6s+wgjyoPy7ickB5lM7/MxQVdpaUI=", "N6vDmGbYZ0aa9S2JqWSYppiX1AV33QDXGc8FHaF0aQ9y6Hp68UEkI2x5AJQ3URqS+5/x1AuucMH0AOMcLNqODg=="),
 ("jTTf/D0gicaG++cQJ1X4qYaOqk4YPo0p6Mo2B95kJAg=", "LCtewONuYTXljy+oK73/m7CON/vr/e1r4aDaVE3xDnc=", "GsomH3aBo6qBHaNGzZZ/pNOviBTbZrUfpthgYU5jAmU=,wHvznjZDA9L8dgQGEj7wf1/QGxunE5/WYdxUpQX4Umc=,ZMxkDV7epUgmpix38jBfWv42VeMQefypY56dnysikWA=,aEy+/J0AFmjYGTjcv5y942fleEk/0rwqlD+kXSn0vCM=,QJMHfIYUraWdJKzenROtgLyjU9MrDtDDwFfDNIcjCHA=", "aGUXY5bBYoDmw4x1muwHzKp1w2sITQMeDfsyxv9EUDc=,qh0wfC/wAdclIJ79R+IIpPJLJM5aBe/i5i54dQOn3Vk=,zCi7XaHyO/b9SfN2AYuJcC60zqnIorkXMjjbixhEKxk=,XlBf7DyH5FtcUyr9Gfnj8i3cnKKPtWGHXm/LpIQX4gM=,wHtZg2i40wdxQvHehZEunTHiODSuEMv8suwFaqynmTQ=", "osUDqpps33Jw0k7vEHFCAk+iywlE7YrXrX5RfqC0olA=", "LnD9wlZrDo3v6dw56owm6NazoBLKwtqMPWdtxSRVWxc=", "KVEotBgIaz5Rymqpy4paroHGQyD/80FdvLCrONxDzQUWgNZxZ6aiCJ2VxIGP+6+86FZXS1sXGgs3dwft/VMCCw=="),
         ];
-        for i in 0..vectors.len() {
-            let (k, Y, P, Q, M_b64, Z_b64, dleq_b64) = vectors[i];
+        for (k, Y, P, Q, M_b64, Z_b64, dleq_b64) in vectors {
 
             let server_key = SigningKey::decode_base64(k).unwrap();
 

--- a/src/dleq.rs
+++ b/src/dleq.rs
@@ -379,7 +379,7 @@ mod tests {
 
         let proof = DLEQProof::_new::<Sha512, _>(&mut rng, P, Q, &key1);
 
-        assert!(!proof._verify::<Sha512>(P, Q, &key1.public_key).is_ok());
+        assert!(proof._verify::<Sha512>(P, Q, &key1.public_key).is_err());
     }
 
     #[allow(non_snake_case)]

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -582,8 +582,6 @@ mod tests {
     use rand::rngs::OsRng;
     use sha2::Sha512;
 
-    use base64;
-
     use super::*;
     type HmacSha512 = Hmac<Sha512>;
 

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -603,8 +603,7 @@ mod tests {
             ("N8oRiMuSrYdp9TMKp++AP8ridXqdX6BoPOucx2eRCQE=", "mnikks9ySHzZGMgoPZ0SRA8/JJkMh5aA+m3eqeMfqTE=", "9sNH3G618rH0vy3TKBMNRQDKOb66LUKBo9jOtMsezeN4sgAp+2pMVDMS5BATkVxXAW5dpoGUTMJ3+cfnX0plSg==", "f44zH9r/YnCyaHZnKtEc/68diotEo1GjQ5MWepNEXAk=", "EEH0FTbmxN5XoXnAHmIH0y4VjcixJ5U9T8WqXgP2IAg=", "Km0KASMeIqj0s5vswz+WEYptTx2Y0fOb9cVjb+UKexw=", "lNDdKND+R/JmDrM08Q7w7ePoXT7/hgzGU6xVBU5RFig="),
             ("Nye8fMOQJv1HjCY6qxG0Br661wjd8OwNI1O0ZbkmGAc=", "5szoRS3/9jdVTmhswiS9yyaLeC2I0CfBAUzfe0zGjz8=", "OkOqxU+boJmNIhmzusoRGUDVJLfPlGd9bFV3UPpNueEHfu21um4zwQSuJUQ8hr8VgzU63fb93Rmk/0kRiOPUhw==", "ZBztTnJvQKmPkxfgzGzufhRa6o4oUPublpOIhODHKA4=", "lD1eLLmRw7ebLOd51OQSps51cZGTIg2DM+GL38bQQww=", "qA27hu9S60UX0jfnWJQgUBllQvfOPu+jQVkphi6Sv24=", "HhPZFQiNAYzG+niNmUiWut2g/YMhox86h1XyZypQfVk="),
         ];
-        for i in 0..vectors.len() {
-            let (k, Y, seed, r, P, Q, W) = vectors[i];
+        for (k, Y, seed, r, P, Q, W) in vectors {
 
             let server_key = SigningKey::decode_base64(k).unwrap();
             let seed = base64::decode(seed).unwrap();

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -632,7 +632,7 @@ mod tests {
             W_bits.copy_from_slice(&W_bytes[..32]);
             let W = CompressedRistretto(W_bits);
 
-            let unblinded_token_expected = UnblindedToken { W: W, t: token.t };
+            let unblinded_token_expected = UnblindedToken { W, t: token.t };
             assert!(unblinded_token.encode_base64() == unblinded_token_expected.encode_base64());
         }
     }


### PR DESCRIPTION
Address clippy lints on the test code

- Iterate over test vectors directly (instead of indexing)
- Remove redundant `use` import
- Remove redundant struct initializer label
- Simplify an assertion

This addresses everything in `cargo clippy --all-targets` under rust 1.74.1, except for the unused function in `benchmark.rs`. Changes will conflict with similar fixes in #33.