### PR TITLE
Remove unnecessary cfg function.

### DIFF
--- a/src/dleq.rs
+++ b/src/dleq.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::vec::Vec;
 
-#[cfg(all(feature = "std"))]
+#[cfg(feature = "std")]
 use std::vec::Vec;
 
 use core::iter;


### PR DESCRIPTION
Fixes a clippy lint: `all` isn't necessary when there's only one argument.