### PR TITLE
Migrate clippy lint to stable rust

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly-2021-10-17
-            components: clippy
-            override: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/dleq.rs
+++ b/src/dleq.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::vec::Vec;
 
-#[cfg(all(feature = "std"))]
+#[cfg(feature = "std")]
 use std::vec::Vec;
 
 use core::iter;


### PR DESCRIPTION
Clippy ci job was actually failing because we no longer build under the 2021-10-17 nightly; use the stable rust toolchain from the runner image instead.