### PR TITLE
Remove obsolete clippy directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 #![deny(missing_docs)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 //! [`tests/e2e.rs`]: javascript:void(0)
 //! [a more detailed writeup is also available]: #cryptographic-protocol
 //! [`T`]: struct.TokenPreimage.html#method.T


### PR DESCRIPTION
The feature is just `clippy` now, which recent clippy warns about, breaking ci runs. We don't fail the single-character variable name lint any more, so just remove the directive entirely.