### PR TITLE
Remove unused rand_core dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ curve25519-dalek = { version = "4", default-features = false, features = ["preco
 digest = "0.10"
 hmac = "0.12"
 rand = { version = "0.8", default-features = false }
-rand_core = "0.6"
 rand_chacha = "0.3"
 subtle = { version = "^2.2", default-features = false }
 zeroize = "1.3"


### PR DESCRIPTION
This is no longer necessary since merlin support was removed in v2.0.0.