### PR TITLE
fix: fix redemption benchmark

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -24,7 +24,7 @@ pub fn e2e_server_benchmarks(c: &mut Criterion) {
         unblinded_tokens: Vec::new(),
     };
 
-    let mut server = Server {
+    let server = Server {
         signing_key,
         spent_tokens: Vec::new(),
     };
@@ -37,12 +37,28 @@ pub fn e2e_server_benchmarks(c: &mut Criterion) {
         });
     });
 
+    let signing_resp = server.sign_tokens(signing_req);
+    client.store_signed_tokens(signing_resp).unwrap();
+
     let redeem_request = client.redeem_tokens();
 
     c.bench_function("redeem tokens", |b| {
-        b.iter(|| {
-            server.redeem_tokens(&redeem_request);
-        });
+        b.iter_batched(
+            || {
+                // Setup: create a fresh server with empty spent_tokens. This
+                // is required because otherwise the server would reject already
+                // spent tokens in the benchmark iterations
+                Server {
+                    signing_key: server.signing_key.clone(),
+                    spent_tokens: Vec::new(),
+                }
+            },
+            |mut fresh_server| {
+                // Only this part is measured
+                fresh_server.redeem_tokens(&redeem_request);
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 }
 


### PR DESCRIPTION
## Description

The redemption benchmark was running with an empty redeem request, leading to wrong results. After implementing this fix:

```
Benchmarking sign pre-tokens: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.0s, enable flat sampling, or reduce sample count to 60.
sign pre-tokens         time:   [1.2416 ms 1.2541 ms 1.2656 ms]
                        change: [−0.4193% +0.3511% +1.2056%] (p = 0.41 > 0.05)
                        No change in performance detected.

Benchmarking redeem tokens: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.0s, enable flat sampling, or reduce sample count to 70.
redeem tokens           time:   [848.07 µs 848.75 µs 849.41 µs]
                        change: [+331461792% +333432036% +334658403%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
  ```